### PR TITLE
Add RADEv2 digital voice support to trx_v2-userland

### DIFF
--- a/system_services/init/modem.service
+++ b/system_services/init/modem.service
@@ -5,7 +5,11 @@ Description=HERMES open modem (mercury) daemon
 Type=exec
 User=root
 Group=root
+<<<<<<< HEAD
 ExecStart=/usr/bin/mercury -v
+=======
+ExecStart=/usr/bin/mercury
+>>>>>>> a516f03 (systemd: simplify modem.service)
 KillSignal=SIGTERM
 IgnoreSIGPIPE=no
 Restart=always

--- a/system_services/init/modem.service
+++ b/system_services/init/modem.service
@@ -5,11 +5,7 @@ Description=HERMES open modem (mercury) daemon
 Type=exec
 User=root
 Group=root
-<<<<<<< HEAD
 ExecStart=/usr/bin/mercury -v
-=======
-ExecStart=/usr/bin/mercury
->>>>>>> a516f03 (systemd: simplify modem.service)
 KillSignal=SIGTERM
 IgnoreSIGPIPE=no
 Restart=always

--- a/system_services/init/sbitx.service
+++ b/system_services/init/sbitx.service
@@ -7,6 +7,8 @@ ExecStart=/usr/bin/sbitx_controller
 KillSignal=SIGTERM
 IgnoreSIGPIPE=no
 Restart=always
+Environment=PATH=/opt/radae/env/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+WorkingDirectory=/opt/radae
 
 [Install]
 WantedBy=multi-user.target

--- a/system_services/init/sbitx.service
+++ b/system_services/init/sbitx.service
@@ -7,8 +7,7 @@ ExecStart=/usr/bin/sbitx_controller
 KillSignal=SIGTERM
 IgnoreSIGPIPE=no
 Restart=always
-Environment=PATH=/opt/radae/env/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-WorkingDirectory=/opt/radae
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [Install]
 WantedBy=multi-user.target

--- a/trx_v2-userland/Makefile
+++ b/trx_v2-userland/Makefile
@@ -45,8 +45,8 @@ GPIOLIB_OBJS=gpiolib/gpiolib.o gpiolib/gpiochip_bcm2712.o gpiolib/gpiochip_bcm28
 
 all: sbitx_controller sbitx_client
 
-sbitx_controller: sbitx_i2c.o sbitx_core.o sbitx_gpio.o sbitx_si5351.o sbitx_websocket.o sbitx_shm.o shm_utils.o cfg_utils.o mongoose.o sbitx_controller.o sbitx_alsa.o sbitx_buffer.o sbitx_dsp.o ring_buffer.o $(GPIOLIB_OBJS)
-	$(CC) -o sbitx_controller sbitx_i2c.o sbitx_core.o sbitx_gpio.o sbitx_si5351.o sbitx_websocket.o sbitx_shm.o shm_utils.o cfg_utils.o mongoose.o sbitx_controller.o sbitx_alsa.o sbitx_buffer.o sbitx_dsp.o ring_buffer.o  $(GPIOLIB_OBJS) $(LDFLAGS)
+sbitx_controller: sbitx_i2c.o sbitx_core.o sbitx_gpio.o sbitx_si5351.o sbitx_websocket.o sbitx_shm.o shm_utils.o cfg_utils.o mongoose.o sbitx_controller.o sbitx_alsa.o sbitx_buffer.o sbitx_dsp.o sbitx_radae.o ring_buffer.o $(GPIOLIB_OBJS)
+	$(CC) -o sbitx_controller sbitx_i2c.o sbitx_core.o sbitx_gpio.o sbitx_si5351.o sbitx_websocket.o sbitx_shm.o shm_utils.o cfg_utils.o mongoose.o sbitx_controller.o sbitx_alsa.o sbitx_buffer.o sbitx_dsp.o sbitx_radae.o ring_buffer.o  $(GPIOLIB_OBJS) $(LDFLAGS)
 
 sbitx_client: sbitx_client.c shm_utils.c sbitx_io.c help.h
 	$(CC) $(CFLAGS) sbitx_client.c sbitx_io.c shm_utils.c -o sbitx_client -lpthread
@@ -90,6 +90,8 @@ sbitx_alsa.o: sbitx_alsa.c sbitx_alsa.h
 sbitx_dsp.o: sbitx_dsp.c sbitx_dsp.h
 	$(CC) -c $(CFLAGS) sbitx_dsp.c -o sbitx_dsp.o
 
+sbitx_radae.o: sbitx_radae.c sbitx_radae.h
+	$(CC) -c $(CFLAGS) sbitx_radae.c -o sbitx_radae.o
 
 sbitx_buffer.o: sbitx_buffer.c sbitx_buffer.h
 	$(CC) -c $(CFLAGS) sbitx_buffer.c -o sbitx_buffer.o

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -96,6 +96,74 @@ Example:
 * sbitx_controller
 
 
+# RADEv2 Digital Voice Mode
+
+This software supports RADEv2 (Radio Autoencoder Version 2) for digital voice
+transmission over HF. When enabled, speech is encoded using the RADAE ML-based
+codec and transmitted within the SSB passband.
+
+## RADEv2 Prerequisites
+
+1. Clone the RADAE repository:
+```bash
+cd /path/to/hermes-net
+git clone https://github.com/drowe67/radae.git
+git checkout dr-radev2
+```
+
+2. Build RADAE (read ../radae/README.md - THIS IS INCOMPLETE):
+```bash
+cd radae
+mkdir build && cd build
+cmake ..
+make
+```
+
+3. Install Python dependencies:
+```bash
+pip3 install torch numpy matplotlib
+```
+
+4. Ensure the RADEv2 model files are present:
+   - `radae/250725/checkpoints/checkpoint_epoch_200.pth` (main model)
+   - `radae/250725a_ml_sync` (frame sync model)
+
+## Building with RADEv2 Support
+
+Build as usual - RADEv2 support is included automatically:
+```bash
+cd trx_v2-userland
+make
+```
+
+## Using Digital Voice Mode
+
+Enable digital voice via the sbitx_client:
+```bash
+sbitx_client -c set_digital_voice -a 1 -p 0    # Enable digital voice on profile 0
+sbitx_client -c set_digital_voice -a 0 -p 0    # Disable digital voice
+sbitx_client -c get_digital_voice -p 0         # Check digital voice status
+```
+
+When digital voice is enabled:
+- **TX**: Speech from mic/loopback is encoded via LPCNet feature extraction,
+  processed through the RADAE encoder, and the resulting modem waveform
+  is placed in the SSB passband.
+- **RX**: The received SSB signal is decoded by RADAE, and
+  synthesized back to speech via LPCNet FARGAN synthesis.
+
+## Technical Details
+
+- Speech sample rate: 16kHz (LPCNet)
+- Modem sample rate: 8kHz (RADAE)
+- Radio sample rate: 96kHz
+- RADEv2 parameters: latent_dim=56, w1_dec=128
+- Model: 250725 checkpoint
+
+The digital voice processing runs as subprocess pipelines:
+- TX: `lpcnet_demo -features` → `inference.py` → modem
+- RX: `radae_rxe.py` → `lpcnet_demo -fargan-synthesis` → speech
+
 # Author
 
 Rafael Diniz @ Rhizomatica

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -126,7 +126,11 @@ pip3 install torch numpy matplotlib
 
 4. Ensure the RADEv2 model files are present:
    - `radae/250725/checkpoints/checkpoint_epoch_200.pth` (main model)
-   - `radae/250725a_ml_sync` (frame sync model)
+   - `radae/250725a_ml_sync` (ML frame sync model, passed to the RX wrapper
+     via `--frame_sync_model_name`)
+
+   The paths are hard-coded in `sbitx_radae.h` as `RADAE_MODEL_PATH` and
+   `RADAE_SYNC_MODEL_PATH`; override them there if you relocate the files.
 
 ## Building with RADEv2 Support
 
@@ -154,15 +158,25 @@ When digital voice is enabled:
 
 ## Technical Details
 
-- Speech sample rate: 16kHz (LPCNet)
-- Modem sample rate: 8kHz (RADAE)
-- Radio sample rate: 96kHz
-- RADEv2 parameters: latent_dim=56, w1_dec=128
-- Model: 250725 checkpoint
+- Speech sample rate: 16 kHz (LPCNet / FARGAN)
+- Modem sample rate: 8 kHz (RADAE, complex baseband)
+- Radio sample rate: 96 kHz
+- RADEv2 waveform: OFDM with Nc=14 carriers, Ns=2 symbols/frame, M=128,
+  Ncp=32 (4 ms cyclic prefix), no pilots
+- RADEv2 ML parameters: latent_dim=56, Nzmf=1, w1_dec=128, auxdata enabled,
+  peak+bottleneck=3 hard clipper (constant-envelope output)
+- Frame sync via the `250725a_ml_sync` ML classifier
+- Models: `250725/checkpoints/checkpoint_epoch_200.pth` + `250725a_ml_sync`
 
-The digital voice processing runs as subprocess pipelines:
-- TX: `lpcnet_demo -features` → `inference.py` → modem
-- RX: `radae_rxe.py` → `lpcnet_demo -fargan-synthesis` → speech
+The digital voice processing runs as subprocess pipelines backed by the
+streaming V2 wrappers in `../radae`:
+
+- TX: `lpcnet_demo -features` → `radae_txe2.py` → modem IQ
+- RX: `radae_rxe2.py` → `lpcnet_demo -fargan-synthesis` → speech
+
+Both wrappers exchange 36-float FARGAN feature vectors with `lpcnet_demo`
+and complex `float32` IQ at 8 kHz with the radio, so they drop into the
+pipes without any extra reshape stage on the C side.
 
 # Author
 

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -178,6 +178,12 @@ Both wrappers exchange 36-float FARGAN feature vectors with `lpcnet_demo`
 and complex `float32` IQ at 8 kHz with the radio, so they drop into the
 pipes without any extra reshape stage on the C side.
 
+If the native RX path needs to be rolled back in the field, edit
+`trx_v2-userland/sbitx_radae.c` and change the RX command back to:
+`python3 -u radae_rxe2.py --model_name ... --frame_sync_model_name ...`.
+Then remove `RADAE_RX_BINARY_PATH` from that `snprintf(...)` argument list or
+simply revert commit `0708f81`, and rebuild `trx_v2-userland`.
+
 # Author
 
 Rafael Diniz @ Rhizomatica

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -171,18 +171,25 @@ When digital voice is enabled:
 The digital voice processing runs as subprocess pipelines backed by the
 V2 tools in `../radae`:
 
-- TX: `lpcnet_demo -features` → `radae_txe2.py` → modem IQ
+- TX: `lpcnet_demo -features` → `radae_tx_v2` → modem IQ
 - RX: `radae_rx_v2` → `lpcnet_demo -fargan-synthesis` → speech
 
 Both wrappers exchange 36-float FARGAN feature vectors with `lpcnet_demo`
 and complex `float32` IQ at 8 kHz with the radio, so they drop into the
-pipes without any extra reshape stage on the C side.
+pipes without any extra reshape stage on the C side.  The native TX
+honours the same `--pid_file` / SIGUSR1 EOO contract that
+`radae_txe2.py` did, so `radae_tx_emit_eoo` keeps working unchanged.
 
 If the native RX path needs to be rolled back in the field, edit
 `trx_v2-userland/sbitx_radae.c` and change the RX command back to:
 `python3 -u radae_rxe2.py --model_name ... --frame_sync_model_name ...`.
 Then remove `RADAE_RX_BINARY_PATH` from that `snprintf(...)` argument list or
 simply revert commit `0708f81`, and rebuild `trx_v2-userland`.
+
+If the native TX path needs to be rolled back, edit the TX `snprintf` in
+`sbitx_radae.c` to invoke `python3 -u radae_txe2.py --model_name %s
+--pid_file %s` instead of the `RADAE_TX_BINARY_PATH` form, or simply
+revert the V2 TX-wiring commit and rebuild `trx_v2-userland`.
 
 # Author
 

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -185,10 +185,10 @@ The digital voice subprocess pipelines are:
 - **RADEv1 TX**: `lpcnet_demo -features` -> `radae_tx` -> modem IQ
 - **RADEv1 RX**: `radae_rx` -> `lpcnet_demo -fargan-synthesis` -> speech
 
-EOO behavior differs by version:
+EOO behavior is now aligned across both versions:
 
 - **RADEv2** uses the native `--pid_file` / `SIGUSR1` EOO contract
-- **RADEv1** emits EOO when the TX pipeline stdin closes at end-of-over
+- **RADEv1** now accepts the same `--pid_file` / `SIGUSR1` EOO contract
 
 # Author
 

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -169,10 +169,10 @@ When digital voice is enabled:
 - Models: `250725/checkpoints/checkpoint_epoch_200.pth` + `250725a_ml_sync`
 
 The digital voice processing runs as subprocess pipelines backed by the
-streaming V2 wrappers in `../radae`:
+V2 tools in `../radae`:
 
 - TX: `lpcnet_demo -features` → `radae_txe2.py` → modem IQ
-- RX: `radae_rxe2.py` → `lpcnet_demo -fargan-synthesis` → speech
+- RX: `radae_rx_v2` → `lpcnet_demo -fargan-synthesis` → speech
 
 Both wrappers exchange 36-float FARGAN feature vectors with `lpcnet_demo`
 and complex `float32` IQ at 8 kHz with the radio, so they drop into the
@@ -181,4 +181,3 @@ pipes without any extra reshape stage on the C side.
 # Author
 
 Rafael Diniz @ Rhizomatica
-

--- a/trx_v2-userland/README.md
+++ b/trx_v2-userland/README.md
@@ -96,51 +96,57 @@ Example:
 * sbitx_controller
 
 
-# RADEv2 Digital Voice Mode
+# RADE Digital Voice Mode
 
-This software supports RADEv2 (Radio Autoencoder Version 2) for digital voice
-transmission over HF. When enabled, speech is encoded using the RADAE ML-based
-codec and transmitted within the SSB passband.
+This software supports two native-C digital voice stacks over HF:
 
-## RADEv2 Prerequisites
+- **RADEv2** from `Rhizomatica/radae`, installed at `/opt/radae`
+- **RADEv1** from `Rhizomatica/radae_nopy`, installed at `/opt/radae_nopy`
 
-1. Clone the RADAE repository:
-```bash
-cd /path/to/hermes-net
-git clone https://github.com/drowe67/radae.git
-git checkout dr-radev2
+The installer builds both side-by-side. The active stack is selected
+system-wide from `/etc/sbitx/user.ini`:
+
+```ini
+[main]
+rade_version=v2
 ```
 
-2. Build RADAE (read ../radae/README.md - THIS IS INCOMPLETE):
+Supported values are:
+
+- `v2` - default production path
+- `v1` - RADEv1 A/B comparison path
+
+Switching versions takes effect after restarting `sbitx`:
+
 ```bash
-cd radae
-mkdir build && cd build
-cmake ..
-make
+sudo systemctl restart sbitx
 ```
 
-3. Install Python dependencies:
-```bash
-pip3 install torch numpy matplotlib
-```
+## Prerequisites
 
-4. Ensure the RADEv2 model files are present:
-   - `radae/250725/checkpoints/checkpoint_epoch_200.pth` (main model)
-   - `radae/250725a_ml_sync` (ML frame sync model, passed to the RX wrapper
-     via `--frame_sync_model_name`)
+The expected installer-built paths are:
 
-   The paths are hard-coded in `sbitx_radae.h` as `RADAE_MODEL_PATH` and
-   `RADAE_SYNC_MODEL_PATH`; override them there if you relocate the files.
+- `/opt/radae/build/src/lpcnet_demo`
+- `/opt/radae/build/src/radae_tx_v2`
+- `/opt/radae/build/src/radae_rx_v2`
+- `/opt/radae_nopy/build/src/lpcnet_demo`
+- `/opt/radae_nopy/build/src/radae_tx`
+- `/opt/radae_nopy/build/src/radae_rx`
 
-## Building with RADEv2 Support
+RADEv2 still requires its compiled-in checkpoint assets under `/opt/radae`
+(`250725/checkpoints/checkpoint_epoch_200.pth` and `250725a_ml_sync`).
+RADEv1 (`radae_nopy`) has built-in weights and needs no runtime model files.
 
-Build as usual - RADEv2 support is included automatically:
+## Building with digital voice support
+
+Build as usual:
+
 ```bash
 cd trx_v2-userland
 make
 ```
 
-## Using Digital Voice Mode
+## Using digital voice mode
 
 Enable digital voice via the sbitx_client:
 ```bash
@@ -150,11 +156,16 @@ sbitx_client -c get_digital_voice -p 0         # Check digital voice status
 ```
 
 When digital voice is enabled:
+
 - **TX**: Speech from mic/loopback is encoded via LPCNet feature extraction,
-  processed through the RADAE encoder, and the resulting modem waveform
+  processed through the selected RADE encoder, and the resulting modem waveform
   is placed in the SSB passband.
-- **RX**: The received SSB signal is decoded by RADAE, and
+- **RX**: The received SSB signal is decoded by the selected RADE receiver and
   synthesized back to speech via LPCNet FARGAN synthesis.
+
+At startup the controller logs the selected RADE version and the TX/RX command
+lines, so `journalctl -u sbitx` is the quickest way to confirm which stack is
+active.
 
 ## Technical Details
 
@@ -165,31 +176,19 @@ When digital voice is enabled:
   Ncp=32 (4 ms cyclic prefix), no pilots
 - RADEv2 ML parameters: latent_dim=56, Nzmf=1, w1_dec=128, auxdata enabled,
   peak+bottleneck=3 hard clipper (constant-envelope output)
-- Frame sync via the `250725a_ml_sync` ML classifier
-- Models: `250725/checkpoints/checkpoint_epoch_200.pth` + `250725a_ml_sync`
+- RADEv2 frame sync via the `250725a_ml_sync` ML classifier
 
-The digital voice processing runs as subprocess pipelines backed by the
-V2 tools in `../radae`:
+The digital voice subprocess pipelines are:
 
-- TX: `lpcnet_demo -features` → `radae_tx_v2` → modem IQ
-- RX: `radae_rx_v2` → `lpcnet_demo -fargan-synthesis` → speech
+- **RADEv2 TX**: `lpcnet_demo -features` -> `radae_tx_v2` -> modem IQ
+- **RADEv2 RX**: `radae_rx_v2` -> `lpcnet_demo -fargan-synthesis` -> speech
+- **RADEv1 TX**: `lpcnet_demo -features` -> `radae_tx` -> modem IQ
+- **RADEv1 RX**: `radae_rx` -> `lpcnet_demo -fargan-synthesis` -> speech
 
-Both wrappers exchange 36-float FARGAN feature vectors with `lpcnet_demo`
-and complex `float32` IQ at 8 kHz with the radio, so they drop into the
-pipes without any extra reshape stage on the C side.  The native TX
-honours the same `--pid_file` / SIGUSR1 EOO contract that
-`radae_txe2.py` did, so `radae_tx_emit_eoo` keeps working unchanged.
+EOO behavior differs by version:
 
-If the native RX path needs to be rolled back in the field, edit
-`trx_v2-userland/sbitx_radae.c` and change the RX command back to:
-`python3 -u radae_rxe2.py --model_name ... --frame_sync_model_name ...`.
-Then remove `RADAE_RX_BINARY_PATH` from that `snprintf(...)` argument list or
-simply revert commit `0708f81`, and rebuild `trx_v2-userland`.
-
-If the native TX path needs to be rolled back, edit the TX `snprintf` in
-`sbitx_radae.c` to invoke `python3 -u radae_txe2.py --model_name %s
---pid_file %s` instead of the `RADAE_TX_BINARY_PATH` form, or simply
-revert the V2 TX-wiring commit and rebuild `trx_v2-userland`.
+- **RADEv2** uses the native `--pid_file` / `SIGUSR1` EOO contract
+- **RADEv1** emits EOO when the TX pipeline stdin closes at end-of-over
 
 # Author
 

--- a/trx_v2-userland/config/user.ini
+++ b/trx_v2-userland/config/user.ini
@@ -3,6 +3,7 @@ current_profile=0
 default_profile=0
 default_profile_fallback_timeout=600
 step_size=100
+rade_version=v2
 
 [profile0]
 freq=7050000

--- a/trx_v2-userland/config/user.ini.mercury
+++ b/trx_v2-userland/config/user.ini.mercury
@@ -4,6 +4,7 @@ current_profile                = 0
 default_profile                = 0
 default_profile_fallback_timeout = 600
 step_size                      = 100
+rade_version                   = v2
 
 
 [profile0]
@@ -22,4 +23,3 @@ enable_knob_volume             = 1
 enable_knob_frequency          = 0
 enable_ptt                     = 0
 digital_voice                  = 0
-

--- a/trx_v2-userland/sbitx_alsa.c
+++ b/trx_v2-userland/sbitx_alsa.c
@@ -25,6 +25,10 @@
 #include <time.h>
 #include <stdbool.h>
 #include <stdatomic.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "sbitx_alsa.h"
 #include "sbitx_dsp.h"
@@ -35,6 +39,10 @@ char *radio_playback_dev = "hw:0,0";
 char *loop_capture_dev = "hw:2,1";
 char *loop_playback_dev = "hw:1,0";
 
+#define MIC_INJECT_PATH "/tmp/sbitx_mic_inject.s32"
+#define RX_SPEAKER_DUMP_TRIGGER "/tmp/sbitx_rx_speaker_dump"
+#define RX_SPEAKER_DUMP_PATH "/tmp/sbitx_rx_speaker_dump.s32"
+
 // mixer device
 char *radio_ctl = "hw:0";
 
@@ -42,6 +50,10 @@ snd_pcm_t *pcm_capture_handle;
 snd_pcm_t *pcm_play_handle;
 snd_pcm_t *loopback_capture_handle;
 snd_pcm_t *loopback_play_handle;
+
+static int mic_inject_fd = -1;
+static bool mic_inject_missing_logged = false;
+static FILE *rx_speaker_dump_fp = NULL;
 
 unsigned int hw_rate = 96000; /* Sample rate */
 snd_pcm_uframes_t hw_period_size = 512; // in frames
@@ -60,6 +72,103 @@ extern _Atomic bool shutdown_;
 
 // should we allow level control even in IO-ONLY mode?
 #define ALLOW_ALSA_LEVELS_IN_IO_ONLY 1
+
+static void close_mic_inject(void)
+{
+    if (mic_inject_fd >= 0)
+        close(mic_inject_fd);
+
+    mic_inject_fd = -1;
+}
+
+static void close_rx_speaker_dump(void)
+{
+    if (rx_speaker_dump_fp)
+        fclose(rx_speaker_dump_fp);
+
+    rx_speaker_dump_fp = NULL;
+}
+
+// Optional test hook: if /tmp/sbitx_mic_inject.s32 exists, use it as the TX
+// source for the normal mic path. Format must be raw S32_LE, 96 kHz, mono.
+static bool read_mic_inject(uint8_t *buffer, uint32_t size)
+{
+    size_t offset = 0;
+
+    while (offset < size)
+    {
+        if (mic_inject_fd < 0)
+        {
+            struct stat st;
+
+            mic_inject_fd = open(MIC_INJECT_PATH, O_RDONLY | O_CLOEXEC);
+            if (mic_inject_fd < 0)
+            {
+                if (!mic_inject_missing_logged && errno != ENOENT)
+                    fprintf(stderr, "Could not open mic inject file %s (%s)\n", MIC_INJECT_PATH, strerror(errno));
+
+                mic_inject_missing_logged = true;
+                return false;
+            }
+
+            if (fstat(mic_inject_fd, &st) == 0 && S_ISREG(st.st_mode) && st.st_size == 0)
+            {
+                fprintf(stderr, "Mic inject file %s is empty\n", MIC_INJECT_PATH);
+                close_mic_inject();
+                mic_inject_missing_logged = true;
+                return false;
+            }
+
+            fprintf(stderr, "Mic inject active: %s\n", MIC_INJECT_PATH);
+            mic_inject_missing_logged = false;
+        }
+
+        ssize_t n = read(mic_inject_fd, buffer + offset, size - offset);
+        if (n > 0)
+        {
+            offset += (size_t) n;
+            continue;
+        }
+
+        if (n == 0)
+        {
+            if (lseek(mic_inject_fd, 0, SEEK_SET) >= 0)
+                continue;
+
+            fprintf(stderr, "Mic inject stream ended for %s\n", MIC_INJECT_PATH);
+            close_mic_inject();
+            return false;
+        }
+
+        fprintf(stderr, "Mic inject read failed for %s (%s)\n", MIC_INJECT_PATH, strerror(errno));
+        close_mic_inject();
+        return false;
+    }
+
+    return true;
+}
+
+// Optional test hook: if /tmp/sbitx_rx_speaker_dump exists, dump the exact
+// 96 kHz mono S32_LE speaker buffer sent to the audio output.
+static void maybe_dump_rx_speaker(const uint8_t *buffer, uint32_t size, bool active_rx)
+{
+    if (!active_rx || !buffer || size == 0)
+        return;
+
+    if (!rx_speaker_dump_fp && access(RX_SPEAKER_DUMP_TRIGGER, F_OK) == 0)
+    {
+        rx_speaker_dump_fp = fopen(RX_SPEAKER_DUMP_PATH, "wb");
+        if (!rx_speaker_dump_fp)
+            fprintf(stderr, "Could not open RX speaker dump file %s (%s)\n", RX_SPEAKER_DUMP_PATH, strerror(errno));
+        else
+            fprintf(stderr, "RX speaker dump active: %s\n", RX_SPEAKER_DUMP_PATH);
+    }
+
+    if (!rx_speaker_dump_fp)
+        return;
+
+    fwrite(buffer, 1, size, rx_speaker_dump_fp);
+}
 
 void show_alsa(snd_pcm_t *handle, snd_pcm_hw_params_t *params)
 {
@@ -907,6 +1016,7 @@ void *control_thread(void *device_ptr)
 
     uint8_t *buffer_radio_to_dsp = malloc(buffer_size);
     uint8_t *buffer_mic_to_dsp = malloc(buffer_size);
+    uint8_t *buffer_mic_inject = malloc(buffer_size);
     uint8_t *buffer_loop_to_dsp = malloc(buffer_size);
 
     uint8_t *signal_to_tx;
@@ -947,12 +1057,16 @@ void *control_thread(void *device_ptr)
         else
         {
             clear_buffer(loopback_to_dsp);
-            signal_to_tx = buffer_mic_to_dsp;
+            if (radio_h_snd->txrx_state == IN_TX && read_mic_inject(buffer_mic_inject, buffer_size))
+                signal_to_tx = buffer_mic_inject;
+            else
+                signal_to_tx = buffer_mic_to_dsp;
         }
 
         if (radio_h_snd->txrx_state == IN_RX)
         {
             dsp_process_rx(buffer_radio_to_dsp, output_speaker, output_loopback, output_tx, block_size);
+            maybe_dump_rx_speaker(output_speaker, buffer_size, true);
         }
         else
         {
@@ -982,6 +1096,9 @@ void *control_thread(void *device_ptr)
     free(output_tx);
     free(output_speaker);
     free(output_loopback);
+    free(buffer_mic_inject);
+    close_mic_inject();
+    close_rx_speaker_dump();
 
     return NULL;
 }

--- a/trx_v2-userland/sbitx_core.c
+++ b/trx_v2-userland/sbitx_core.c
@@ -449,10 +449,41 @@ void swr_protection_check(radio *radio_h)
     }
 }
 
+// Final hardware half of TX->RX. For digital voice this runs only after the
+// EOO frame has already been kicked into the TX pipeline and had time to drain
+// through DSP/ALSA. Keeping the PA drop here avoids duplicating the long tail
+// of tr_switch() between the immediate and deferred paths.
+static void tr_finish_switch_to_rx(radio *radio_h, bool dv_active)
+{
+    usleep(10000);
+
+    set_speaker_level(radio_h->profiles[radio_h->profile_active_idx].speaker_level);
+    set_tx_level(0);
+
+    usleep(1000);
+    lpf_off(radio_h);
+    usleep(1000);
+    set_drive(TX_LINE, DRIVE_LOW);
+    usleep(1000);
+    lpf_set(radio_h);
+
+    rx_starting = true;
+    radio_h->txrx_state = IN_RX;
+    radio_h->dv_rx_switch_pending = false;
+    radio_h->dv_rx_switch_delay_ticks = 0;
+
+    // Clear RADAE TX flow state only after the hardware is back in RX, so the
+    // next PTT-on cannot race the tail of the over that just finished.
+    if (dv_active)
+        dsp_radae_tx_end_over();
+}
+
 // TODO: all DSP and ALSA calls here or tr_switch? or not? lets keep things separate?
 void tr_switch(radio *radio_h, bool txrx_state)
 {
     if (txrx_state == radio_h->txrx_state)
+        return;
+    if (txrx_state == IN_RX && radio_h->dv_rx_switch_pending)
         return;
 
     if (radio_h->swr_protection_enabled)
@@ -465,6 +496,8 @@ void tr_switch(radio *radio_h, bool txrx_state)
     if (txrx_state == IN_TX)
     {
         // printf("IN_TX\n");
+        radio_h->dv_rx_switch_pending = false;
+        radio_h->dv_rx_switch_delay_ticks = 0;
         tx_starting = true;
         radio_h->txrx_state = IN_TX;
 
@@ -481,40 +514,24 @@ void tr_switch(radio *radio_h, bool txrx_state)
     {
         // printf("IN_RX\n");
 
-        // Digital-voice: ask the RADAE TX pipeline to emit its V2
-        // end-of-over frame BEFORE we drop PA drive.  Without this the
-        // receiver only sees the carrier disappear, so its decoder
-        // keeps its sync state and the next over starts with a stale
-        // tracker.  The DSP is still in IN_TX here (txrx_state flips
-        // at the end of this branch), so dsp_process_tx keeps draining
-        // the TX modem buffer into the DAC while the EOO IQ arrives.
-        // 150 ms covers ~30 ms of EOO IQ + the ALSA+DSP tail.
+        // Digital-voice PTT-off is two-stage:
+        // 1) trigger EOO immediately and return to the caller
+        // 2) complete the actual TX->RX hardware drop a few io_tick periods
+        //    later, after the queued EOO IQ has had time to reach the DAC
+        //
+        // This keeps control-plane calls like `sbitx_client -c ptt_off`
+        // responsive without losing the explicit EOO marker that the far-end
+        // decoder needs to reset cleanly between overs.
         bool dv_active = radio_h->profiles[radio_h->profile_active_idx].digital_voice;
         bool dv_eoo_sent = dsp_radae_tx_emit_eoo_if_dv();
-        if (dv_eoo_sent)
-            usleep(150000);
+        if (dv_eoo_sent) {
+            radio_h->dv_rx_switch_pending = true;
+            radio_h->dv_rx_switch_delay_ticks = 15;
+            radio_h->send_ws_update = true;
+            return;
+        }
 
-        usleep(10000);
-
-        set_speaker_level(radio_h->profiles[radio_h->profile_active_idx].speaker_level);
-        set_tx_level(0);
-
-        usleep(1000);
-        lpf_off(radio_h);
-        usleep(1000);
-        set_drive(TX_LINE, DRIVE_LOW);
-        usleep(1000);
-        lpf_set(radio_h);
-
-        rx_starting = true;
-        radio_h->txrx_state = IN_RX;
-
-        // Clear RADAE TX flow state AFTER txrx_state flips to IN_RX, so
-        // no further dsp_process_tx block can spuriously re-fire
-        // radae_tx_start via the lazy-start path in
-        // dsp_prepare_digital_voice_tx.
-        if (dv_active)
-            dsp_radae_tx_end_over();
+        tr_finish_switch_to_rx(radio_h, dv_active);
     }
 
     radio_h->send_ws_update = true;
@@ -532,6 +549,18 @@ void io_tick(radio *radio_h)
     bool set_dirty_ws = false;
 
     ticks++;
+
+    if (radio_h->dv_rx_switch_pending && radio_h->txrx_state == IN_TX)
+    {
+        if (radio_h->dv_rx_switch_delay_ticks > 0)
+            radio_h->dv_rx_switch_delay_ticks--;
+        if (radio_h->dv_rx_switch_delay_ticks == 0)
+        {
+            bool dv_active = radio_h->profiles[radio_h->profile_active_idx].digital_voice;
+            tr_finish_switch_to_rx(radio_h, dv_active);
+            radio_h->send_ws_update = true;
+        }
+    }
 
     if (last_key_state != radio_h->key_down)
     {

--- a/trx_v2-userland/sbitx_core.c
+++ b/trx_v2-userland/sbitx_core.c
@@ -480,6 +480,19 @@ void tr_switch(radio *radio_h, bool txrx_state)
     else
     {
         // printf("IN_RX\n");
+
+        // Digital-voice: ask the RADAE TX pipeline to emit its V2
+        // end-of-over frame BEFORE we drop PA drive.  Without this the
+        // receiver only sees the carrier disappear, so its decoder
+        // keeps its sync state and the next over starts with a stale
+        // tracker.  The DSP is still in IN_TX here (txrx_state flips
+        // at the end of this branch), so dsp_process_tx keeps draining
+        // the TX modem buffer into the DAC while the EOO IQ arrives.
+        // 150 ms covers ~30 ms of EOO IQ + the ALSA+DSP tail.
+        bool dv_eoo_sent = dsp_radae_tx_emit_eoo_if_dv();
+        if (dv_eoo_sent)
+            usleep(150000);
+
         usleep(10000);
 
         set_speaker_level(radio_h->profiles[radio_h->profile_active_idx].speaker_level);
@@ -494,6 +507,13 @@ void tr_switch(radio *radio_h, bool txrx_state)
 
         rx_starting = true;
         radio_h->txrx_state = IN_RX;
+
+        // Clear RADAE TX flow state AFTER txrx_state flips to IN_RX, so
+        // no further dsp_process_tx block can spuriously re-fire
+        // radae_tx_start via the lazy-start path in
+        // dsp_prepare_digital_voice_tx.
+        if (dv_eoo_sent)
+            dsp_radae_tx_end_over();
     }
 
     radio_h->send_ws_update = true;

--- a/trx_v2-userland/sbitx_core.c
+++ b/trx_v2-userland/sbitx_core.c
@@ -489,6 +489,7 @@ void tr_switch(radio *radio_h, bool txrx_state)
         // at the end of this branch), so dsp_process_tx keeps draining
         // the TX modem buffer into the DAC while the EOO IQ arrives.
         // 150 ms covers ~30 ms of EOO IQ + the ALSA+DSP tail.
+        bool dv_active = radio_h->profiles[radio_h->profile_active_idx].digital_voice;
         bool dv_eoo_sent = dsp_radae_tx_emit_eoo_if_dv();
         if (dv_eoo_sent)
             usleep(150000);
@@ -512,7 +513,7 @@ void tr_switch(radio *radio_h, bool txrx_state)
         // no further dsp_process_tx block can spuriously re-fire
         // radae_tx_start via the lazy-start path in
         // dsp_prepare_digital_voice_tx.
-        if (dv_eoo_sent)
+        if (dv_active)
             dsp_radae_tx_end_over();
     }
 

--- a/trx_v2-userland/sbitx_core.h
+++ b/trx_v2-userland/sbitx_core.h
@@ -205,6 +205,11 @@ typedef struct
     dictionary *cfg_user;
     _Atomic bool cfg_user_dirty;
     _Atomic bool send_ws_update;
+    // DV TX->RX handoff is split in two phases: after PTT-off we trigger EOO
+    // immediately, then finish the hardware drop a few io_tick periods later
+    // so the queued IQ tail reaches the DAC before PA drive is removed.
+    _Atomic bool dv_rx_switch_pending;
+    _Atomic uint32_t dv_rx_switch_delay_ticks;
 
     _Atomic uint32_t bytes_transmitted;
     _Atomic uint32_t bytes_received;

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -538,12 +538,10 @@ void dsp_process_tx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
 
     double multiplier = get_band_multiplier() * (double) radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].power_level_percentage / 100.0;
     RADAE_AMPL_LOG("tx_ssb mult*pct", multiplier);
-    // DV through the shared pipeline uses complex input with |tx|=1 (hard
-    // clipper, constant envelope) and no sideband-halving, so creal(fft_time)
-    // stays near unit magnitude where SSB voice only peaks there. Keeping the
-    // SSB constant of 4000 overdrives the analog chain by ~4x, splattering the
-    // spectrum. Scale DV down to put the DAC peak near SSB voice peak (~4.5e8).
-    const double tx_scale = digital_voice ? 900.0 : 4000.0;
+    // DV is constant-envelope (PAR ~0 dB) where voice has ~10 dB PAR, so at
+    // equal peak the PA sees ~10 dB more average power and splatters. Scale
+    // DV so its peak lands below SSB voice peak (~4.5e8 on this radio).
+    const double tx_scale = digital_voice ? 400.0 : 4000.0;
     for (i = 0; i < MAX_BINS / 2; i++)
     {
         double _ssb_pre = creal(fft_time[i+(MAX_BINS/2)]);

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -353,13 +353,19 @@ void dsp_process_rx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
         // Process through RADAE digital voice decoder
         dsp_process_digital_voice_rx(rx_baseband, block_size, speech_out);
         
-        // Output decoded speech
+        // Output decoded speech. FARGAN output arrives at roughly -18 dBFS
+        // peak / -28 dBFS mean -- inaudible against typical SSB voice RX. Boost
+        // by 5x and clip to [-0.95, 0.95] to stay well under int32 overflow.
         int32_t *output_speaker_int = (int32_t *)output_speaker;
         int32_t *output_loopback_int = (int32_t *)output_loopback;
-        
+
+        const double dv_rx_gain = 5.0;
         for (int k = 0; k < block_size; k++)
         {
-            output_speaker_int[k] = (int32_t)(speech_out[k] * MAX_SAMPLE_VALUE);
+            double s = speech_out[k] * dv_rx_gain;
+            if (s >  0.95) s =  0.95;
+            if (s < -0.95) s = -0.95;
+            output_speaker_int[k] = (int32_t)(s * MAX_SAMPLE_VALUE);
             if ((k % 2) == 0)
             {
                 output_loopback_int[k] = output_speaker_int[k] << 4;

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -538,11 +538,17 @@ void dsp_process_tx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
 
     double multiplier = get_band_multiplier() * (double) radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].power_level_percentage / 100.0;
     RADAE_AMPL_LOG("tx_ssb mult*pct", multiplier);
+    // DV through the shared pipeline uses complex input with |tx|=1 (hard
+    // clipper, constant envelope) and no sideband-halving, so creal(fft_time)
+    // stays near unit magnitude where SSB voice only peaks there. Keeping the
+    // SSB constant of 4000 overdrives the analog chain by ~4x, splattering the
+    // spectrum. Scale DV down to put the DAC peak near SSB voice peak (~4.5e8).
+    const double tx_scale = digital_voice ? 900.0 : 4000.0;
     for (i = 0; i < MAX_BINS / 2; i++)
     {
         double _ssb_pre = creal(fft_time[i+(MAX_BINS/2)]);
         RADAE_AMPL_LOG("tx_ssb fft_time_re", _ssb_pre);
-        signal_output_int[i] = (int32_t) (_ssb_pre * 4000.0 * multiplier); // we just chose an appropriate level...
+        signal_output_int[i] = (int32_t) (_ssb_pre * tx_scale * multiplier);
         signal_output_int[i] <<= 8;
         RADAE_AMPL_LOG("tx_ssb dac_int32", signal_output_int[i]);
     }

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -138,12 +138,11 @@ static void dsp_process_digital_voice_tx(double *signal_input_f, uint32_t block_
         // multiplier=0 apart from signal=0 at a glance.
         RADAE_AMPL_LOG("tx_dv mult*pct", multiplier);
 
-        // RADAE hard-clipper produces unit-amplitude baseband (|tx|=1), whereas
-        // the SSB path's FFT-domain values can be orders of magnitude larger.
-        // Re-using 4000.0 left the DV signal ~0.03% of int32 full-scale ->
-        // essentially no RF. Bump by 100x; still headroom (post-<<8 peak ~6e7
-        // is ~3% FS) and we can fine-tune once SSB amplitude is characterised.
-        const double dv_scale = 4000.0 * 100.0;
+        // RADAE hard-clipper produces unit-amplitude baseband (|tx|=1). SSB
+        // voice peaks measured at ~4.5e8 post-<<8; to give DV the same PEP
+        // (and since DV is constant-envelope, equivalent continuous output)
+        // we scale 700x over the SSB constant of 4000.0 -> peak ~4.3e8.
+        const double dv_scale = 4000.0 * 700.0;
         for (int i = 0; i < output_samples; i++) {
             signal_output_int[i] = (int32_t)(radae_baseband[i] * dv_scale * multiplier);
             signal_output_int[i] <<= 8;

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -87,80 +87,80 @@ static radae_context radae_ctx;
 static _Atomic bool radae_tx_active = false;
 
 // Buffers for RADAE sample rate conversion
-static float radae_speech_in[2048];   // 16kHz speech input
-static float radae_speech_out[2048];  // 16kHz speech output
-static float radae_modem_iq[4096];    // 8kHz complex IQ (interleaved I,Q)
-static double radae_baseband[2048];   // intermediate buffer for sample rate conversion
+static float radae_speech_in[2048];     // 16kHz speech input
+static float radae_speech_out[2048];    // 16kHz speech output
+static float radae_modem_iq[4096];      // 8kHz complex IQ (interleaved I,Q)
+static double radae_baseband_i[2048];   // 96kHz I component (complex IQ, upsampled)
+static double radae_baseband_q[2048];   // 96kHz Q component (complex IQ, upsampled)
 
-// Digital voice TX processing using RADAE
-// Takes 96kHz or 48kHz speech input, produces 96kHz modulated output
-static void dsp_process_digital_voice_tx(double *signal_input_f, uint32_t block_size, int32_t *signal_output_int, bool input_is_48k_stereo)
+// Digital voice TX preparation using RADAE.
+//
+// Loads fft_in (and fft_m for overlap-save) with upsampled complex RADAE IQ so
+// the normal SSB TX pipeline (FFT -> tx_filter -> zero sideband -> TUNED_BINS
+// rotate -> IFFT -> creal) places the OFDM at the same IF (+/-24 kHz) the
+// analog front end expects for voice.  Key differences vs. real-audio load:
+//
+//   - Both I and Q are kept (fft_in real=I, imag=Q).  RADAE V2 is complex
+//     baseband with asymmetric spectrum; dropping Q halves energy and
+//     introduces a mirror image.
+//   - For LSB profiles we conjugate (flip Q sign), which puts the positive-
+//     baseband OFDM content on the *negative* side of the FFT.  That way the
+//     SSB zero-sideband step (LSB zeros positive freqs) keeps the signal
+//     instead of destroying it.
+//
+// RADAE Python pipeline still needs 16 kHz speech from the mic/loopback, so
+// the speech feed is unchanged.
+static void dsp_prepare_digital_voice_tx(double *signal_input_f, uint32_t block_size, bool input_is_48k_stereo)
 {
-    // Start RADAE TX if not already running
     if (!radae_tx_active) {
         radae_tx_start(&radae_ctx);
         radae_tx_active = true;
     }
 
-    // Resample input to 16kHz for RADAE
-    // signal_input_f is always 96kHz: either directly from mic, or after 2x interpolation from 48kHz loopback
-    (void)input_is_48k_stereo;  // Not needed - signal_input_f is always 96kHz
+    // signal_input_f is always 96 kHz (upsampled from loopback in the caller)
+    (void)input_is_48k_stereo;
     int speech_16k_len;
     resample_96k_to_16k(signal_input_f, block_size, radae_speech_in, &speech_16k_len);
-
-    // Feed speech to RADAE TX
     radae_tx_write_speech(&radae_ctx, radae_speech_in, speech_16k_len);
 
-    // Try to get modem IQ from RADAE TX
-    // Limit to avoid buffer overflow: 8kHz->96kHz upsampling multiplies by 12,
-    // and radae_baseband buffer is 2048 samples, so max input is 2048/12 = 170 samples
-    int max_modem_samples = 2048 / 12;  // = 170 samples max
+    // Read RADAE IQ.  Cap by block_size/12 so the 1:12 upsample cannot
+    // overflow radae_baseband_*; any extra stays in the ring buffer for
+    // the next call.  Undersupply is fine -- we zero-pad.
+    int max_modem_samples = (int)block_size / 12;
     int modem_samples = radae_tx_read_modem_iq(&radae_ctx, radae_modem_iq, max_modem_samples);
 
+    int n = 0;
     if (modem_samples > 0) {
-        // RADAE outputs complex IQ at 8kHz - the OFDM waveform is already in baseband
-        // Just extract the real part (I component) and upsample to 96kHz for SSB TX
-        // No carrier mixing needed - RADAE waveform already fits in SSB passband
-        
-        int baseband_len;
-        float real_part[modem_samples];
-        for (int i = 0; i < modem_samples; i++) {
-            real_part[i] = radae_modem_iq[i*2];  // Just take I component
+        float iq_i_8k[modem_samples];
+        float iq_q_8k[modem_samples];
+        for (int s = 0; s < modem_samples; s++) {
+            iq_i_8k[s] = radae_modem_iq[s*2];
+            iq_q_8k[s] = radae_modem_iq[s*2+1];
         }
-        
-        resample_8k_to_96k(real_part, modem_samples, radae_baseband, &baseband_len);
-        
-        // Output to radio TX
-        double multiplier = get_band_multiplier() * (double) radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].power_level_percentage / 100.0;
-        int output_samples = (baseband_len < MAX_BINS/2) ? baseband_len : MAX_BINS/2;
+        int len_i, len_q;
+        resample_8k_to_96k(iq_i_8k, modem_samples, radae_baseband_i, &len_i);
+        resample_8k_to_96k(iq_q_8k, modem_samples, radae_baseband_q, &len_q);
+        n = len_i < len_q ? len_i : len_q;
+        if (n > (int)block_size) n = (int)block_size;
+    }
 
-        // One-line summary of the gain stages every 1s so we can tell
-        // multiplier=0 apart from signal=0 at a glance.
-        RADAE_AMPL_LOG("tx_dv mult*pct", multiplier);
+    bool is_lsb = (radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].mode == MODE_LSB);
+    double q_sign = is_lsb ? -1.0 : 1.0;
 
-        // RADAE hard-clipper produces unit-amplitude baseband (|tx|=1). SSB
-        // voice peaks measured at ~4.5e8 post-<<8; to give DV the same PEP
-        // (and since DV is constant-envelope, equivalent continuous output)
-        // we scale 700x over the SSB constant of 4000.0 -> peak ~4.3e8.
-        const double dv_scale = 4000.0 * 700.0;
-        for (int i = 0; i < output_samples; i++) {
-            signal_output_int[i] = (int32_t)(radae_baseband[i] * dv_scale * multiplier);
-            signal_output_int[i] <<= 8;
-            // Peak/mean |int32| reaching the TX DAC (post-scale, post-<<8).
-            RADAE_AMPL_LOG("tx_dv dac_int32", signal_output_int[i]);
-        }
-        // Also track the pre-scale upsampled baseband, so we can isolate
-        // whether the signal lost amplitude before or during the scale step.
-        for (int i = 0; i < output_samples; i++) {
-            RADAE_AMPL_LOG("tx_dv baseband96k", radae_baseband[i]);
-        }
-        // Zero pad the rest if needed
-        for (int i = output_samples; i < MAX_BINS/2; i++) {
-            signal_output_int[i] = 0;
-        }
-    } else {
-        // No modem output yet, output silence
-        memset(signal_output_int, 0, MAX_BINS/2 * sizeof(int32_t));
+    // Overlap-save: fft_in[0..MAX_BINS/2) was just filled from previous block's
+    // fft_m via memcpy in the caller.  We fill the *new* half (MAX_BINS/2..MAX_BINS)
+    // and update fft_m for the next block.
+    for (int k = 0; k < n; k++) {
+        __real__ fft_m[k]               = radae_baseband_i[k];
+        __imag__ fft_m[k]               = q_sign * radae_baseband_q[k];
+        __real__ fft_in[MAX_BINS/2 + k] = radae_baseband_i[k];
+        __imag__ fft_in[MAX_BINS/2 + k] = q_sign * radae_baseband_q[k];
+
+        RADAE_AMPL_LOG("tx_dv baseband96k_i", radae_baseband_i[k]);
+    }
+    for (int k = n; k < (int)block_size; k++) {
+        fft_m[k]               = 0;
+        fft_in[MAX_BINS/2 + k] = 0;
     }
 }
 
@@ -174,29 +174,70 @@ static void dsp_process_digital_voice_rx(double *rx_baseband, uint32_t block_siz
     int modem_len;
     float modem_8k[block_size / 12 + 1];
     resample_96k_to_8k(rx_baseband, block_size, modem_8k, &modem_len);
-    
+
+    // Amplitude of the real baseband entering the RADAE decoder. Peak > 0
+    // means *something* is coming in (carrier, noise, or a DV signal); peak
+    // near 0 means the SSB demod path is delivering silence.
+    for (int i = 0; i < modem_len; i++) {
+        RADAE_AMPL_LOG("rx_dv baseband_in", modem_8k[i]);
+    }
+
+    // Optional raw 8 kHz float32 dump of the real baseband that feeds the
+    // RADAE RX. Enabled by touching /tmp/radae_rx_dump (file's presence is
+    // checked once per call). Lets us capture a live over-the-air signal
+    // and offline-decode it with radae_rxe2.py to separate a pipeline
+    // issue from a sync/SNR issue.
+    {
+        static FILE *dump_fp = NULL;
+        static int dump_checked = 0;
+        if (!dump_checked) {
+            dump_checked = 1;
+            if (access("/tmp/radae_rx_dump", F_OK) == 0) {
+                dump_fp = fopen("/tmp/radae_rx_dump.f32", "wb");
+                if (dump_fp)
+                    fprintf(stderr, "RADAE RX dump: writing /tmp/radae_rx_dump.f32\n");
+            }
+        }
+        if (dump_fp) {
+            fwrite(modem_8k, sizeof(float), modem_len, dump_fp);
+        }
+    }
+
     // Create complex IQ for RADAE: I = real signal, Q = 0
     for (int i = 0; i < modem_len; i++) {
         radae_modem_iq[i*2] = modem_8k[i];      // I component = real signal
         radae_modem_iq[i*2+1] = 0.0f;           // Q component = 0
     }
-    
+
     // Feed modem IQ to RADAE RX
     radae_rx_write_modem_iq(&radae_ctx, radae_modem_iq, modem_len);
-    
+
     // Try to get decoded speech from RADAE RX
     // Limit to MAX_BINS/12 samples (170) since 16kHz->96kHz upsampling multiplies by 6,
     // and we need output to fit in MAX_BINS/2 (1024) buffer
     int max_speech_samples = (MAX_BINS / 2) / 6;  // = 170 samples max
     int speech_samples = radae_rx_read_speech(&radae_ctx, radae_speech_out, max_speech_samples);
-    
+
     if (speech_samples > 0) {
+        // Amplitude of the 16 kHz speech the decoder produced this block.
+        // If rx_dv baseband_in is non-zero but speech_out stays at 0, the
+        // RADAE decoder is receiving signal but failing to sync/decode.
+        for (int i = 0; i < speech_samples; i++) {
+            RADAE_AMPL_LOG("rx_dv speech_out", radae_speech_out[i]);
+        }
+
         // Upsample 16kHz speech to 96kHz for speaker output
         int output_len;
         resample_16k_to_96k(radae_speech_out, speech_samples, speech_out, &output_len);
         // Zero remaining samples to avoid stale data if output_len < block_size
         if ((uint32_t)output_len < block_size) {
             memset(speech_out + output_len, 0, (block_size - output_len) * sizeof(double));
+        }
+
+        // Amplitude of the 96 kHz speech heading to the speaker ALSA device,
+        // post scale to int32. This is what the user would actually hear.
+        for (int i = 0; i < (int)block_size; i++) {
+            RADAE_AMPL_LOG("rx_dv speaker_i32", (int64_t)(speech_out[i] * MAX_SAMPLE_VALUE));
         }
     } else {
         // No speech output yet
@@ -408,51 +449,56 @@ void dsp_process_tx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
         }
     }
 
-    // Digital voice mode using RADAE
-    if (radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].digital_voice)
+    bool digital_voice = radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].digital_voice;
+
+    // Digital voice mode using RADAE: load fft_in/fft_m with upsampled complex
+    // RADAE IQ, then fall through to the shared SSB pipeline (FFT, filter,
+    // zero-sideband, TUNED_BINS rotate, IFFT, DAC) so the OFDM lands at the
+    // same IF the analog front end expects for voice.
+    if (digital_voice)
     {
-        dsp_process_digital_voice_tx(signal_input_f, block_size, signal_output_int, input_is_48k_stereo);
-        memset(output_loopback, 0, block_size * (snd_pcm_format_width(format) / 8));
-        memset(output_speaker, 0, block_size * (snd_pcm_format_width(format) / 8));
-        return;
+        dsp_prepare_digital_voice_tx(signal_input_f, block_size, input_is_48k_stereo);
     }
-    else if (radae_tx_active)
+    else
     {
-        // Stop RADAE TX if it was running but digital_voice is now disabled
-        radae_tx_stop(&radae_ctx);
-        radae_tx_active = false;
-    }
+        if (radae_tx_active)
+        {
+            // Stop RADAE TX if it was running but digital_voice is now disabled
+            radae_tx_stop(&radae_ctx);
+            radae_tx_active = false;
+        }
 
 #if DEBUG_DSP_ == 1
-    static double max_i_sample = -100000000;
-    static double min_i_sample = 100000000;
+        static double max_i_sample = -100000000;
+        static double min_i_sample = 100000000;
 #endif
 
-    //gather the samples into a time domain array
-    for (i = MAX_BINS/2; i < MAX_BINS; i++, j++)
-    {
-        i_sample = signal_input_f[j];
+        //gather the samples into a time domain array
+        for (i = MAX_BINS/2; i < MAX_BINS; i++, j++)
+        {
+            i_sample = signal_input_f[j];
 
 #if DEBUG_DSP_ == 1
-        if (max_i_sample < i_sample)
-        {
-            max_i_sample = i_sample;
-            printf("input_tx %d\n", signal_input_int[j]);
-            printf("max_tx_sample %f\n\n", max_i_sample);
-        }
-        if (min_i_sample > i_sample)
-        {
-            min_i_sample = i_sample;
-            printf("input_tx %d\n", signal_input_int[j]);
-            printf("min_tx_sample %f\n\n", min_i_sample);
-        }
+            if (max_i_sample < i_sample)
+            {
+                max_i_sample = i_sample;
+                printf("input_tx %d\n", signal_input_int[j]);
+                printf("max_tx_sample %f\n\n", max_i_sample);
+            }
+            if (min_i_sample > i_sample)
+            {
+                min_i_sample = i_sample;
+                printf("input_tx %d\n", signal_input_int[j]);
+                printf("min_tx_sample %f\n\n", min_i_sample);
+            }
 #endif
 
-        __real__ fft_m[j] = i_sample;
-        __imag__ fft_m[j] = 0;
+            __real__ fft_m[j] = i_sample;
+            __imag__ fft_m[j] = 0;
 
-        __real__ fft_in[i]  = i_sample;
-        __imag__ fft_in[i]  = 0;
+            __real__ fft_in[i]  = i_sample;
+            __imag__ fft_in[i]  = 0;
+        }
     }
 
     //convert to frequency

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -138,8 +138,14 @@ static void dsp_process_digital_voice_tx(double *signal_input_f, uint32_t block_
         // multiplier=0 apart from signal=0 at a glance.
         RADAE_AMPL_LOG("tx_dv mult*pct", multiplier);
 
+        // RADAE hard-clipper produces unit-amplitude baseband (|tx|=1), whereas
+        // the SSB path's FFT-domain values can be orders of magnitude larger.
+        // Re-using 4000.0 left the DV signal ~0.03% of int32 full-scale ->
+        // essentially no RF. Bump by 100x; still headroom (post-<<8 peak ~6e7
+        // is ~3% FS) and we can fine-tune once SSB amplitude is characterised.
+        const double dv_scale = 4000.0 * 100.0;
         for (int i = 0; i < output_samples; i++) {
-            signal_output_int[i] = (int32_t)(radae_baseband[i] * 4000.0 * multiplier);
+            signal_output_int[i] = (int32_t)(radae_baseband[i] * dv_scale * multiplier);
             signal_output_int[i] <<= 8;
             // Peak/mean |int32| reaching the TX DAC (post-scale, post-<<8).
             RADAE_AMPL_LOG("tx_dv dac_int32", signal_output_int[i]);
@@ -486,10 +492,14 @@ void dsp_process_tx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
     fftw_execute(plan_rev);
 
     double multiplier = get_band_multiplier() * (double) radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].power_level_percentage / 100.0;
+    RADAE_AMPL_LOG("tx_ssb mult*pct", multiplier);
     for (i = 0; i < MAX_BINS / 2; i++)
     {
-        signal_output_int[i] = (int32_t) (creal(fft_time[i+(MAX_BINS/2)]) * 4000.0 * multiplier); // we just chose an appropriate level...
+        double _ssb_pre = creal(fft_time[i+(MAX_BINS/2)]);
+        RADAE_AMPL_LOG("tx_ssb fft_time_re", _ssb_pre);
+        signal_output_int[i] = (int32_t) (_ssb_pre * 4000.0 * multiplier); // we just chose an appropriate level...
         signal_output_int[i] <<= 8;
+        RADAE_AMPL_LOG("tx_ssb dac_int32", signal_output_int[i]);
     }
 
     memset(output_loopback, 0, block_size * (snd_pcm_format_width(format) / 8));

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -133,10 +133,21 @@ static void dsp_process_digital_voice_tx(double *signal_input_f, uint32_t block_
         // Output to radio TX
         double multiplier = get_band_multiplier() * (double) radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].power_level_percentage / 100.0;
         int output_samples = (baseband_len < MAX_BINS/2) ? baseband_len : MAX_BINS/2;
-        
+
+        // One-line summary of the gain stages every 1s so we can tell
+        // multiplier=0 apart from signal=0 at a glance.
+        RADAE_AMPL_LOG("tx_dv mult*pct", multiplier);
+
         for (int i = 0; i < output_samples; i++) {
             signal_output_int[i] = (int32_t)(radae_baseband[i] * 4000.0 * multiplier);
             signal_output_int[i] <<= 8;
+            // Peak/mean |int32| reaching the TX DAC (post-scale, post-<<8).
+            RADAE_AMPL_LOG("tx_dv dac_int32", signal_output_int[i]);
+        }
+        // Also track the pre-scale upsampled baseband, so we can isolate
+        // whether the signal lost amplitude before or during the scale step.
+        for (int i = 0; i < output_samples; i++) {
+            RADAE_AMPL_LOG("tx_dv baseband96k", radae_baseband[i]);
         }
         // Zero pad the rest if needed
         for (int i = output_samples; i < MAX_BINS/2; i++) {

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -28,10 +28,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <alsa/asoundlib.h>
 #include <complex.h>
 #include <fftw3.h>
 #include <math.h>
+#include <unistd.h>
 
 
 #define USE_FFTW
@@ -93,6 +95,25 @@ static float radae_modem_iq[4096];      // 8kHz complex IQ (interleaved I,Q)
 static double radae_baseband_i[2048];   // 96kHz I component (complex IQ, upsampled)
 static double radae_baseband_q[2048];   // 96kHz Q component (complex IQ, upsampled)
 
+static void maybe_dump_tx_modem_iq(const float *iq_samples, int n_complex_samples)
+{
+    static FILE *dump_fp = NULL;
+
+    if (!iq_samples || n_complex_samples <= 0)
+        return;
+
+    if (!dump_fp && access("/tmp/radae_tx_dump", F_OK) == 0) {
+        dump_fp = fopen("/tmp/tx_clip.cf32", "wb");
+        if (dump_fp)
+            fprintf(stderr, "RADAE TX dump: writing /tmp/tx_clip.cf32 (complex)\n");
+    }
+
+    if (!dump_fp)
+        return;
+
+    fwrite(iq_samples, sizeof(float), (size_t)n_complex_samples * 2U, dump_fp);
+}
+
 // Digital voice TX preparation using RADAE.
 //
 // Loads fft_in (and fft_m for overlap-save) with upsampled complex RADAE IQ so
@@ -137,6 +158,7 @@ static void dsp_prepare_digital_voice_tx(double *signal_input_f, uint32_t block_
             iq_i_8k[s] = radae_modem_iq[s*2];
             iq_q_8k[s] = radae_modem_iq[s*2+1];
         }
+        maybe_dump_tx_modem_iq(radae_modem_iq, modem_samples);
         int len_i, len_q;
         resample_8k_to_96k(iq_i_8k, modem_samples, radae_baseband_i, &len_i);
         resample_8k_to_96k(iq_q_8k, modem_samples, radae_baseband_q, &len_q);
@@ -190,14 +212,10 @@ static void dsp_process_digital_voice_rx(double *rx_baseband_i, double *rx_baseb
     // issue from a sync/SNR issue.
     {
         static FILE *dump_fp = NULL;
-        static int dump_checked = 0;
-        if (!dump_checked) {
-            dump_checked = 1;
-            if (access("/tmp/radae_rx_dump", F_OK) == 0) {
-                dump_fp = fopen("/tmp/radae_rx_dump.cf32", "wb");
-                if (dump_fp)
-                    fprintf(stderr, "RADAE RX dump: writing /tmp/radae_rx_dump.cf32 (complex)\n");
-            }
+        if (!dump_fp && access("/tmp/radae_rx_dump", F_OK) == 0) {
+            dump_fp = fopen("/tmp/radae_rx_dump.cf32", "wb");
+            if (dump_fp)
+                fprintf(stderr, "RADAE RX dump: writing /tmp/radae_rx_dump.cf32 (complex)\n");
         }
         if (dump_fp) {
             // Write interleaved complex samples for offline analysis

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -165,24 +165,25 @@ static void dsp_prepare_digital_voice_tx(double *signal_input_f, uint32_t block_
 }
 
 // Digital voice RX processing using RADAE
-// Takes 96kHz received signal, extracts RADAE modem signal, outputs decoded speech
-static void dsp_process_digital_voice_rx(double *rx_baseband, uint32_t block_size, double *speech_out)
+// Takes 96kHz complex IQ from SSB demod (I and Q arrays), outputs decoded speech
+static void dsp_process_digital_voice_rx(double *rx_baseband_i, double *rx_baseband_q, uint32_t block_size, double *speech_out)
 {
-    // Resample 96kHz baseband to 8kHz for RADAE modem
-    // SSB demod gives us real-valued baseband containing the RADAE OFDM waveform
-    // No carrier mixing needed - just resample and create complex IQ with Q=0
-    int modem_len;
-    float modem_8k[block_size / 12 + 1];
-    resample_96k_to_8k(rx_baseband, block_size, modem_8k, &modem_len);
+    // Resample 96kHz complex IQ to 8kHz for RADAE modem
+    // SSB demod (IFFT of filtered/rotated signal) produces complex output;
+    // RADAE OFDM needs both I and Q to decode properly.
+    int modem_len_i, modem_len_q;
+    float modem_8k_i[block_size / 12 + 1];
+    float modem_8k_q[block_size / 12 + 1];
+    resample_96k_to_8k(rx_baseband_i, block_size, modem_8k_i, &modem_len_i);
+    resample_96k_to_8k(rx_baseband_q, block_size, modem_8k_q, &modem_len_q);
+    int modem_len = modem_len_i < modem_len_q ? modem_len_i : modem_len_q;
 
-    // Amplitude of the real baseband entering the RADAE decoder. Peak > 0
-    // means *something* is coming in (carrier, noise, or a DV signal); peak
-    // near 0 means the SSB demod path is delivering silence.
+    // Amplitude of the complex baseband entering the RADAE decoder
     for (int i = 0; i < modem_len; i++) {
-        RADAE_AMPL_LOG("rx_dv baseband_in", modem_8k[i]);
+        RADAE_AMPL_LOG("rx_dv baseband_in", modem_8k_i[i]);
     }
 
-    // Optional raw 8 kHz float32 dump of the real baseband that feeds the
+    // Optional raw 8 kHz complex float32 dump (interleaved I,Q) that feeds the
     // RADAE RX. Enabled by touching /tmp/radae_rx_dump (file's presence is
     // checked once per call). Lets us capture a live over-the-air signal
     // and offline-decode it with radae_rxe2.py to separate a pipeline
@@ -193,20 +194,24 @@ static void dsp_process_digital_voice_rx(double *rx_baseband, uint32_t block_siz
         if (!dump_checked) {
             dump_checked = 1;
             if (access("/tmp/radae_rx_dump", F_OK) == 0) {
-                dump_fp = fopen("/tmp/radae_rx_dump.f32", "wb");
+                dump_fp = fopen("/tmp/radae_rx_dump.cf32", "wb");
                 if (dump_fp)
-                    fprintf(stderr, "RADAE RX dump: writing /tmp/radae_rx_dump.f32\n");
+                    fprintf(stderr, "RADAE RX dump: writing /tmp/radae_rx_dump.cf32 (complex)\n");
             }
         }
         if (dump_fp) {
-            fwrite(modem_8k, sizeof(float), modem_len, dump_fp);
+            // Write interleaved complex samples for offline analysis
+            for (int i = 0; i < modem_len; i++) {
+                fwrite(&modem_8k_i[i], sizeof(float), 1, dump_fp);
+                fwrite(&modem_8k_q[i], sizeof(float), 1, dump_fp);
+            }
         }
     }
 
-    // Create complex IQ for RADAE: I = real signal, Q = 0
+    // Create interleaved complex IQ for RADAE
     for (int i = 0; i < modem_len; i++) {
-        radae_modem_iq[i*2] = modem_8k[i];      // I component = real signal
-        radae_modem_iq[i*2+1] = 0.0f;           // Q component = 0
+        radae_modem_iq[i*2] = modem_8k_i[i];     // I component
+        radae_modem_iq[i*2+1] = modem_8k_q[i];   // Q component
     }
 
     // Feed modem IQ to RADAE RX
@@ -261,6 +266,8 @@ void dsp_process_rx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
     {
         fft_reset_m_bins();
         clear_buffers();
+        // Flush RADAE RX buffers to discard stale data from before TX
+        radae_rx_flush(&radae_ctx);
         rx_starting = false;
     }
 
@@ -341,17 +348,20 @@ void dsp_process_rx(uint8_t *signal_input, uint8_t *output_speaker, uint8_t *out
     // STEP 8.5: Digital voice RX processing using RADAE
     if (radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].digital_voice)
     {
-        // Extract demodulated baseband for RADAE processing
-        static double rx_baseband[MAX_BINS/2];
+        // Extract demodulated complex IQ from SSB pipeline for RADAE processing
+        // The IFFT output (fft_time) contains complex signal; RADAE needs both components.
+        static double rx_baseband_i[MAX_BINS/2];
+        static double rx_baseband_q[MAX_BINS/2];
         static double speech_out[MAX_BINS/2];
         
         for (int k = 0; k < MAX_BINS/2; k++)
         {
-            rx_baseband[k] = cimag(fft_time[k + (MAX_BINS/2)]);
+            rx_baseband_i[k] = creal(fft_time[k + (MAX_BINS/2)]);
+            rx_baseband_q[k] = cimag(fft_time[k + (MAX_BINS/2)]);
         }
         
         // Process through RADAE digital voice decoder
-        dsp_process_digital_voice_rx(rx_baseband, block_size, speech_out);
+        dsp_process_digital_voice_rx(rx_baseband_i, rx_baseband_q, block_size, speech_out);
         
         // Output decoded speech. FARGAN output arrives at roughly -18 dBFS
         // peak / -28 dBFS mean -- inaudible against typical SSB voice RX. Boost

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -88,6 +88,28 @@ _Atomic bool rx_starting = false;
 static radae_context radae_ctx;
 static _Atomic bool radae_tx_active = false;
 
+// See sbitx_dsp.h for contract; kept out-of-line here because radae_ctx
+// is deliberately file-private.  We also require radae_tx_active so
+// we don't signal into a pipeline that never ran any speech (first
+// PTT in a fresh DV session would otherwise emit a bogus EOO).
+bool dsp_radae_tx_emit_eoo_if_dv(void)
+{
+    if (!radae_tx_active)
+        return false;
+    if (!radio_h_dsp ||
+        !radio_h_dsp->profiles[radio_h_dsp->profile_active_idx].digital_voice)
+        return false;
+    return radae_tx_emit_eoo(&radae_ctx);
+}
+
+void dsp_radae_tx_end_over(void)
+{
+    if (!radae_tx_active)
+        return;
+    radae_tx_stop(&radae_ctx);
+    radae_tx_active = false;
+}
+
 // Buffers for RADAE sample rate conversion
 static float radae_speech_in[2048];     // 16kHz speech input
 static float radae_speech_out[2048];    // 16kHz speech output
@@ -133,6 +155,16 @@ static void maybe_dump_tx_modem_iq(const float *iq_samples, int n_complex_sample
 // the speech feed is unchanged.
 static void dsp_prepare_digital_voice_tx(double *signal_input_f, uint32_t block_size, bool input_is_48k_stereo)
 {
+    // Race guard: an ALSA block can start while txrx_state == IN_TX but
+    // still be in-flight when tr_switch flips to IN_RX and calls
+    // dsp_radae_tx_end_over (clearing radae_tx_active).  Without this
+    // check, the lazy-start below would spuriously re-fire radae_tx_start
+    // at PTT-off and leave the pipeline in a confused flow-enabled state
+    // for the next PTT.
+    if (!radae_tx_active &&
+        radio_h_dsp && radio_h_dsp->txrx_state != IN_TX)
+        return;
+
     if (!radae_tx_active) {
         radae_tx_start(&radae_ctx);
         radae_tx_active = true;

--- a/trx_v2-userland/sbitx_dsp.c
+++ b/trx_v2-userland/sbitx_dsp.c
@@ -695,7 +695,7 @@ void dsp_init(radio *radio_h)
 
     // Initialize RADAE digital voice subsystem
     printf("Initializing RADAE digital voice subsystem\n");
-    if (!radae_init(&radae_ctx, radio_h, RADAE_DIR)) {
+    if (!radae_init(&radae_ctx, radio_h)) {
         fprintf(stderr, "Warning: RADAE initialization failed, digital voice will not be available\n");
     } else {
         // Start RADAE RX by default (always listening)

--- a/trx_v2-userland/sbitx_dsp.h
+++ b/trx_v2-userland/sbitx_dsp.h
@@ -72,18 +72,18 @@ double get_band_multiplier();
 
 // PTT-off hook used by tr_switch: if the active profile has digital
 // voice enabled, ask the RADAE TX pipeline to emit its V2 end-of-over
-// frame now.  Non-blocking; caller must delay any PA-drive drop long
-// enough for the EOO IQ to flow through the DSP->DAC tail (empirically
-// ~120-180 ms covers subprocess scheduling + ALSA buffering).
+// frame now. Non-blocking. The caller is responsible for deferring the
+// actual TX->RX hardware drop long enough for the queued EOO IQ to
+// reach the DAC (the current core code does this with a short pending
+// state handled from io_tick).
 // Returns true iff the signal was sent; false if no active RADAE
 // session or DV is off.
 bool dsp_radae_tx_emit_eoo_if_dv(void);
 
 // Companion to dsp_radae_tx_emit_eoo_if_dv: clear the RADAE TX
 // flow-control state so the next PTT-on re-enters radae_tx_start
-// cleanly.  Must be called only after the EOO IQ has had time to
-// drain through DSP->DAC (same delay the caller already uses before
-// dropping PA drive), otherwise radae_tx_stop will truncate the EOO
+// cleanly. Must be called only after the EOO IQ has had time to
+// drain through DSP->DAC, otherwise radae_tx_stop will truncate the EOO
 // frame.  No-op if RADAE TX was never active.
 void dsp_radae_tx_end_over(void);
 

--- a/trx_v2-userland/sbitx_dsp.h
+++ b/trx_v2-userland/sbitx_dsp.h
@@ -70,6 +70,23 @@ void dsp_process_agc();
 // the the tx band multiplier
 double get_band_multiplier();
 
+// PTT-off hook used by tr_switch: if the active profile has digital
+// voice enabled, ask the RADAE TX pipeline to emit its V2 end-of-over
+// frame now.  Non-blocking; caller must delay any PA-drive drop long
+// enough for the EOO IQ to flow through the DSP->DAC tail (empirically
+// ~120-180 ms covers subprocess scheduling + ALSA buffering).
+// Returns true iff the signal was sent; false if no active RADAE
+// session or DV is off.
+bool dsp_radae_tx_emit_eoo_if_dv(void);
+
+// Companion to dsp_radae_tx_emit_eoo_if_dv: clear the RADAE TX
+// flow-control state so the next PTT-on re-enters radae_tx_start
+// cleanly.  Must be called only after the EOO IQ has had time to
+// drain through DSP->DAC (same delay the caller already uses before
+// dropping PA drive), otherwise radae_tx_stop will truncate the EOO
+// frame.  No-op if RADAE TX was never active.
+void dsp_radae_tx_end_over(void);
+
 // by Ashhar Farhan, from https://github.com/afarhan/sbitx/blob/main/fft_filter.c
 struct filter *filter_new(int input_length, int impulse_length);
 int filter_tune(struct filter *f, double const low, double const high, double const kaiser_beta);

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -1,0 +1,694 @@
+/*
+ * sBitx RADEv2 Digital Voice Integration
+ *
+ * Copyright (C) 2024-2025 Rhizomatica
+ * Author: Rafael Diniz <rafael@rhizomatica.org>
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ *
+ * RADEv2 - Radio Autoencoder Version 2
+ * Uses subprocess pipelines with Python scripts for encoding/decoding.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <math.h>
+
+#include "sbitx_core.h"
+#include "sbitx_radae.h"
+
+// Helper macros for circular buffer operations
+#define BUFFER_SIZE(write_idx, read_idx, max_size) \
+    (((write_idx) - (read_idx) + (max_size)) % (max_size))
+
+#define BUFFER_FREE(write_idx, read_idx, max_size) \
+    ((max_size) - 1 - BUFFER_SIZE(write_idx, read_idx, max_size))
+
+// TX thread: reads from speech buffer, writes to modem buffer via RADAE pipeline
+static void *radae_tx_thread(void *arg);
+
+// RX thread: reads from modem buffer, writes to speech buffer via RADAE pipeline
+static void *radae_rx_thread(void *arg);
+
+bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir)
+{
+    memset(ctx, 0, sizeof(radae_context));
+    
+    ctx->radio_h = radio_h;
+    strncpy(ctx->radae_dir, radae_dir, sizeof(ctx->radae_dir) - 1);
+    
+    // Initialize mutexes and condition variables
+    pthread_mutex_init(&ctx->tx_mutex, NULL);
+    pthread_mutex_init(&ctx->rx_mutex, NULL);
+    pthread_cond_init(&ctx->tx_cond, NULL);
+    pthread_cond_init(&ctx->rx_cond, NULL);
+    
+    // Allocate circular buffers
+    // TX speech buffer: 16kHz mono float samples
+    ctx->tx_speech_buffer = (float *)calloc(RADAE_SPEECH_BUFFER_SIZE, sizeof(float));
+    if (!ctx->tx_speech_buffer) {
+        fprintf(stderr, "RADAE: Failed to allocate TX speech buffer\n");
+        goto cleanup_mutex;
+    }
+    
+    // TX modem buffer: 8kHz complex IQ (interleaved float pairs)
+    ctx->tx_modem_buffer = (float *)calloc(RADAE_MODEM_BUFFER_SIZE * 2, sizeof(float));
+    if (!ctx->tx_modem_buffer) {
+        fprintf(stderr, "RADAE: Failed to allocate TX modem buffer\n");
+        goto cleanup_tx_speech;
+    }
+    
+    // RX modem buffer: 8kHz complex IQ (interleaved float pairs)
+    ctx->rx_modem_buffer = (float *)calloc(RADAE_MODEM_BUFFER_SIZE * 2, sizeof(float));
+    if (!ctx->rx_modem_buffer) {
+        fprintf(stderr, "RADAE: Failed to allocate RX modem buffer\n");
+        goto cleanup_tx_modem;
+    }
+    
+    // RX speech buffer: 16kHz mono float samples
+    ctx->rx_speech_buffer = (float *)calloc(RADAE_SPEECH_BUFFER_SIZE, sizeof(float));
+    if (!ctx->rx_speech_buffer) {
+        fprintf(stderr, "RADAE: Failed to allocate RX speech buffer\n");
+        goto cleanup_rx_modem;
+    }
+    
+    ctx->initialized = true;
+    ctx->shutdown_requested = false;
+    
+    fprintf(stderr, "RADAE: Initialized with radae_dir=%s\n", ctx->radae_dir);
+    
+    return true;
+
+cleanup_rx_modem:
+    free(ctx->rx_modem_buffer);
+cleanup_tx_modem:
+    free(ctx->tx_modem_buffer);
+cleanup_tx_speech:
+    free(ctx->tx_speech_buffer);
+cleanup_mutex:
+    pthread_mutex_destroy(&ctx->tx_mutex);
+    pthread_mutex_destroy(&ctx->rx_mutex);
+    pthread_cond_destroy(&ctx->tx_cond);
+    pthread_cond_destroy(&ctx->rx_cond);
+    return false;
+}
+
+void radae_shutdown(radae_context *ctx)
+{
+    if (!ctx->initialized)
+        return;
+    
+    ctx->shutdown_requested = true;
+    
+    // Stop TX and RX if running
+    radae_tx_stop(ctx);
+    radae_rx_stop(ctx);
+    
+    // Cleanup
+    pthread_mutex_destroy(&ctx->tx_mutex);
+    pthread_mutex_destroy(&ctx->rx_mutex);
+    pthread_cond_destroy(&ctx->tx_cond);
+    pthread_cond_destroy(&ctx->rx_cond);
+    
+    free(ctx->tx_speech_buffer);
+    free(ctx->tx_modem_buffer);
+    free(ctx->rx_modem_buffer);
+    free(ctx->rx_speech_buffer);
+    
+    ctx->initialized = false;
+    fprintf(stderr, "RADAE: Shutdown complete\n");
+}
+
+bool radae_tx_start(radae_context *ctx)
+{
+    if (!ctx->initialized || ctx->tx_running)
+        return false;
+    
+    ctx->tx_running = true;
+    ctx->tx_speech_buffer_write_idx = 0;
+    ctx->tx_speech_buffer_read_idx = 0;
+    ctx->tx_modem_buffer_write_idx = 0;
+    ctx->tx_modem_buffer_read_idx = 0;
+    
+    // Start TX processing thread
+    if (pthread_create(&ctx->tx_thread, NULL, radae_tx_thread, ctx) != 0) {
+        fprintf(stderr, "RADAE: Failed to create TX thread\n");
+        ctx->tx_running = false;
+        return false;
+    }
+    
+    fprintf(stderr, "RADAE TX: Started\n");
+    return true;
+}
+
+void radae_tx_stop(radae_context *ctx)
+{
+    if (!ctx->tx_running)
+        return;
+    
+    ctx->tx_running = false;
+    
+    // Signal the thread to wake up
+    pthread_cond_signal(&ctx->tx_cond);
+    
+    // Wait for thread to finish
+    pthread_join(ctx->tx_thread, NULL);
+    
+    // Kill any subprocess
+    if (ctx->tx_encoder_pid > 0) {
+        kill(ctx->tx_encoder_pid, SIGTERM);
+        waitpid(ctx->tx_encoder_pid, NULL, 0);
+        ctx->tx_encoder_pid = 0;
+    }
+    
+    fprintf(stderr, "RADAE TX: Stopped\n");
+}
+
+bool radae_rx_start(radae_context *ctx)
+{
+    if (!ctx->initialized || ctx->rx_running)
+        return false;
+    
+    ctx->rx_running = true;
+    ctx->rx_modem_buffer_write_idx = 0;
+    ctx->rx_modem_buffer_read_idx = 0;
+    ctx->rx_speech_buffer_write_idx = 0;
+    ctx->rx_speech_buffer_read_idx = 0;
+    
+    // Start RX processing thread
+    if (pthread_create(&ctx->rx_thread, NULL, radae_rx_thread, ctx) != 0) {
+        fprintf(stderr, "RADAE: Failed to create RX thread\n");
+        ctx->rx_running = false;
+        return false;
+    }
+    
+    fprintf(stderr, "RADAE RX: Started\n");
+    return true;
+}
+
+void radae_rx_stop(radae_context *ctx)
+{
+    if (!ctx->rx_running)
+        return;
+    
+    ctx->rx_running = false;
+    
+    // Signal the thread to wake up
+    pthread_cond_signal(&ctx->rx_cond);
+    
+    // Wait for thread to finish
+    pthread_join(ctx->rx_thread, NULL);
+    
+    // Kill any subprocess
+    if (ctx->rx_decoder_pid > 0) {
+        kill(ctx->rx_decoder_pid, SIGTERM);
+        waitpid(ctx->rx_decoder_pid, NULL, 0);
+        ctx->rx_decoder_pid = 0;
+    }
+    
+    fprintf(stderr, "RADAE RX: Stopped\n");
+}
+
+int radae_tx_write_speech(radae_context *ctx, const float *samples, int n_samples)
+{
+    if (!ctx->tx_running || !samples || n_samples <= 0)
+        return 0;
+    
+    pthread_mutex_lock(&ctx->tx_mutex);
+    
+    int free_space = BUFFER_FREE(ctx->tx_speech_buffer_write_idx, 
+                                  ctx->tx_speech_buffer_read_idx, 
+                                  RADAE_SPEECH_BUFFER_SIZE);
+    int to_write = (n_samples < free_space) ? n_samples : free_space;
+    
+    for (int i = 0; i < to_write; i++) {
+        ctx->tx_speech_buffer[ctx->tx_speech_buffer_write_idx] = samples[i];
+        ctx->tx_speech_buffer_write_idx = (ctx->tx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
+    }
+    
+    pthread_cond_signal(&ctx->tx_cond);
+    pthread_mutex_unlock(&ctx->tx_mutex);
+    
+    return to_write;
+}
+
+int radae_tx_read_modem_iq(radae_context *ctx, float *iq_samples, int max_samples)
+{
+    if (!ctx->tx_running || !iq_samples || max_samples <= 0)
+        return 0;
+    
+    pthread_mutex_lock(&ctx->tx_mutex);
+    
+    // max_samples is number of complex samples, buffer stores interleaved I,Q
+    int available = BUFFER_SIZE(ctx->tx_modem_buffer_write_idx, 
+                                 ctx->tx_modem_buffer_read_idx, 
+                                 RADAE_MODEM_BUFFER_SIZE * 2) / 2;
+    int to_read = (max_samples < available) ? max_samples : available;
+    
+    for (int i = 0; i < to_read * 2; i++) {
+        iq_samples[i] = ctx->tx_modem_buffer[ctx->tx_modem_buffer_read_idx];
+        ctx->tx_modem_buffer_read_idx = (ctx->tx_modem_buffer_read_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
+    }
+    
+    pthread_mutex_unlock(&ctx->tx_mutex);
+    
+    return to_read;
+}
+
+int radae_rx_write_modem_iq(radae_context *ctx, const float *iq_samples, int n_samples)
+{
+    if (!ctx->rx_running || !iq_samples || n_samples <= 0)
+        return 0;
+    
+    pthread_mutex_lock(&ctx->rx_mutex);
+    
+    // n_samples is number of complex samples
+    int free_space = BUFFER_FREE(ctx->rx_modem_buffer_write_idx, 
+                                  ctx->rx_modem_buffer_read_idx, 
+                                  RADAE_MODEM_BUFFER_SIZE * 2) / 2;
+    int to_write = (n_samples < free_space) ? n_samples : free_space;
+    
+    for (int i = 0; i < to_write * 2; i++) {
+        ctx->rx_modem_buffer[ctx->rx_modem_buffer_write_idx] = iq_samples[i];
+        ctx->rx_modem_buffer_write_idx = (ctx->rx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
+    }
+    
+    pthread_cond_signal(&ctx->rx_cond);
+    pthread_mutex_unlock(&ctx->rx_mutex);
+    
+    return to_write;
+}
+
+int radae_rx_read_speech(radae_context *ctx, float *samples, int max_samples)
+{
+    if (!ctx->rx_running || !samples || max_samples <= 0)
+        return 0;
+    
+    pthread_mutex_lock(&ctx->rx_mutex);
+    
+    int available = BUFFER_SIZE(ctx->rx_speech_buffer_write_idx, 
+                                 ctx->rx_speech_buffer_read_idx, 
+                                 RADAE_SPEECH_BUFFER_SIZE);
+    int to_read = (max_samples < available) ? max_samples : available;
+    
+    for (int i = 0; i < to_read; i++) {
+        samples[i] = ctx->rx_speech_buffer[ctx->rx_speech_buffer_read_idx];
+        ctx->rx_speech_buffer_read_idx = (ctx->rx_speech_buffer_read_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
+    }
+    
+    pthread_mutex_unlock(&ctx->rx_mutex);
+    
+    return to_read;
+}
+
+// TX thread implementation
+// Pipeline: speech (16kHz) -> lpcnet_demo -features -> inference.py -> modem IQ (8kHz)
+static void *radae_tx_thread(void *arg)
+{
+    radae_context *ctx = (radae_context *)arg;
+    
+    // Build command for TX pipeline
+    // RADEv2: lpcnet_demo -features -> radae_txe.py -> IQ samples
+    
+    char cmd[2048];
+    snprintf(cmd, sizeof(cmd),
+             "cd %s && "
+             "build/src/lpcnet_demo -features - - | "
+             "python3 radae_txe.py --model_name %s 2>/dev/null",
+             ctx->radae_dir,
+             RADAE_MODEL_PATH);
+    
+    fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
+    
+    // Create pipes for stdin and stdout
+    int stdin_pipe[2], stdout_pipe[2];
+    if (pipe(stdin_pipe) < 0) {
+        fprintf(stderr, "RADAE TX: Failed to create stdin pipe\n");
+        ctx->tx_running = false;
+        return NULL;
+    }
+    if (pipe(stdout_pipe) < 0) {
+        fprintf(stderr, "RADAE TX: Failed to create stdout pipe\n");
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]);
+        ctx->tx_running = false;
+        return NULL;
+    }
+    
+    pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "RADAE TX: Fork failed\n");
+        close(stdin_pipe[0]); close(stdin_pipe[1]);
+        close(stdout_pipe[0]); close(stdout_pipe[1]);
+        ctx->tx_running = false;
+        return NULL;
+    }
+    
+    if (pid == 0) {
+        // Child process
+        close(stdin_pipe[1]);  // Close write end of stdin pipe
+        close(stdout_pipe[0]); // Close read end of stdout pipe
+        
+        dup2(stdin_pipe[0], STDIN_FILENO);
+        dup2(stdout_pipe[1], STDOUT_FILENO);
+        
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+        
+        execl("/bin/sh", "sh", "-c", cmd, NULL);
+        _exit(1);
+    }
+    
+    // Parent process
+    close(stdin_pipe[0]);  // Close read end of stdin pipe
+    close(stdout_pipe[1]); // Close write end of stdout pipe
+    
+    ctx->tx_encoder_pid = pid;
+    
+    int write_fd = stdin_pipe[1];
+    int read_fd = stdout_pipe[0];
+    
+    // Set non-blocking on read
+    int flags = fcntl(read_fd, F_GETFL, 0);
+    fcntl(read_fd, F_SETFL, flags | O_NONBLOCK);
+    
+    // Buffer for reading speech and writing to pipe (16-bit PCM)
+    int16_t pcm_buffer[RADAE_FRAME_SIZE];
+    float speech_buffer[RADAE_FRAME_SIZE];
+    
+    // Buffer for reading IQ from pipe
+    float iq_buffer[4096];
+    
+    while (ctx->tx_running && !ctx->shutdown_requested) {
+        // Check for speech data in buffer
+        pthread_mutex_lock(&ctx->tx_mutex);
+        int available = BUFFER_SIZE(ctx->tx_speech_buffer_write_idx, 
+                                     ctx->tx_speech_buffer_read_idx, 
+                                     RADAE_SPEECH_BUFFER_SIZE);
+        
+        if (available < RADAE_FRAME_SIZE) {
+            // Wait for more data
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_nsec += 10000000; // 10ms timeout
+            if (ts.tv_nsec >= 1000000000) {
+                ts.tv_sec++;
+                ts.tv_nsec -= 1000000000;
+            }
+            pthread_cond_timedwait(&ctx->tx_cond, &ctx->tx_mutex, &ts);
+            pthread_mutex_unlock(&ctx->tx_mutex);
+            
+            // Still try to read output even if no input
+            goto read_output;
+        }
+        
+        // Read speech samples from buffer
+        for (int i = 0; i < RADAE_FRAME_SIZE; i++) {
+            speech_buffer[i] = ctx->tx_speech_buffer[ctx->tx_speech_buffer_read_idx];
+            ctx->tx_speech_buffer_read_idx = (ctx->tx_speech_buffer_read_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
+        }
+        pthread_mutex_unlock(&ctx->tx_mutex);
+        
+        // Convert to 16-bit PCM for lpcnet_demo
+        for (int i = 0; i < RADAE_FRAME_SIZE; i++) {
+            float s = speech_buffer[i] * 32767.0f;
+            if (s > 32767.0f) s = 32767.0f;
+            if (s < -32768.0f) s = -32768.0f;
+            pcm_buffer[i] = (int16_t)s;
+        }
+        
+        // Write to pipeline
+        ssize_t written = write(write_fd, pcm_buffer, RADAE_FRAME_SIZE * sizeof(int16_t));
+        if (written < 0 && errno != EAGAIN) {
+            fprintf(stderr, "RADAE TX: Write error: %s\n", strerror(errno));
+            break;
+        }
+        
+    read_output:
+        // Try to read modem IQ output
+        ssize_t bytes_read = read(read_fd, iq_buffer, sizeof(iq_buffer));
+        if (bytes_read > 0) {
+            int n_floats = bytes_read / sizeof(float);
+            
+            pthread_mutex_lock(&ctx->tx_mutex);
+            int free_space = BUFFER_FREE(ctx->tx_modem_buffer_write_idx, 
+                                          ctx->tx_modem_buffer_read_idx, 
+                                          RADAE_MODEM_BUFFER_SIZE * 2);
+            int to_write = (n_floats < free_space) ? n_floats : free_space;
+            
+            for (int i = 0; i < to_write; i++) {
+                ctx->tx_modem_buffer[ctx->tx_modem_buffer_write_idx] = iq_buffer[i];
+                ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
+            }
+            pthread_mutex_unlock(&ctx->tx_mutex);
+        }
+    }
+    
+    close(write_fd);
+    close(read_fd);
+    
+    // Wait for child process
+    waitpid(pid, NULL, 0);
+    ctx->tx_encoder_pid = 0;
+    
+    fprintf(stderr, "RADAE TX: Thread exiting\n");
+    return NULL;
+}
+
+// RX thread implementation
+// Pipeline: modem IQ (8kHz) -> rx2.py -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
+static void *radae_rx_thread(void *arg)
+{
+    radae_context *ctx = (radae_context *)arg;
+    
+    // RADEv2 RX pipeline: IQ samples -> radae_rxe.py -> features -> lpcnet_demo -fargan-synthesis
+    
+    char cmd[2048];
+    snprintf(cmd, sizeof(cmd),
+             "cd %s && "
+             "python3 radae_rxe.py --model_name %s -v 0 | "
+             "build/src/lpcnet_demo -fargan-synthesis - - 2>/dev/null",
+             ctx->radae_dir,
+             RADAE_MODEL_PATH);
+    
+    fprintf(stderr, "RADAE RX: Starting pipeline: %s\n", cmd);
+    
+    // Create pipes for stdin and stdout
+    int stdin_pipe[2], stdout_pipe[2];
+    if (pipe(stdin_pipe) < 0) {
+        fprintf(stderr, "RADAE RX: Failed to create stdin pipe\n");
+        ctx->rx_running = false;
+        return NULL;
+    }
+    if (pipe(stdout_pipe) < 0) {
+        fprintf(stderr, "RADAE RX: Failed to create stdout pipe\n");
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]);
+        ctx->rx_running = false;
+        return NULL;
+    }
+    
+    pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "RADAE RX: Fork failed\n");
+        close(stdin_pipe[0]); close(stdin_pipe[1]);
+        close(stdout_pipe[0]); close(stdout_pipe[1]);
+        ctx->rx_running = false;
+        return NULL;
+    }
+    
+    if (pid == 0) {
+        // Child process
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        
+        dup2(stdin_pipe[0], STDIN_FILENO);
+        dup2(stdout_pipe[1], STDOUT_FILENO);
+        
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+        
+        execl("/bin/sh", "sh", "-c", cmd, NULL);
+        _exit(1);
+    }
+    
+    // Parent process
+    close(stdin_pipe[0]);
+    close(stdout_pipe[1]);
+    
+    ctx->rx_decoder_pid = pid;
+    
+    int write_fd = stdin_pipe[1];
+    int read_fd = stdout_pipe[0];
+    
+    // Set non-blocking on read
+    int flags = fcntl(read_fd, F_GETFL, 0);
+    fcntl(read_fd, F_SETFL, flags | O_NONBLOCK);
+    
+    float iq_buffer[4096];
+    int16_t pcm_buffer[2048];
+    
+    while (ctx->rx_running && !ctx->shutdown_requested) {
+        // Check for modem IQ data in buffer
+        pthread_mutex_lock(&ctx->rx_mutex);
+        int available = BUFFER_SIZE(ctx->rx_modem_buffer_write_idx, 
+                                     ctx->rx_modem_buffer_read_idx, 
+                                     RADAE_MODEM_BUFFER_SIZE * 2);
+        
+        if (available < 2) {
+            // Wait for more data
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_nsec += 10000000; // 10ms timeout
+            if (ts.tv_nsec >= 1000000000) {
+                ts.tv_sec++;
+                ts.tv_nsec -= 1000000000;
+            }
+            pthread_cond_timedwait(&ctx->rx_cond, &ctx->rx_mutex, &ts);
+            pthread_mutex_unlock(&ctx->rx_mutex);
+            
+            goto read_output_rx;
+        }
+        
+        // Read up to 4096 floats from buffer
+        int to_read = (available < 4096) ? available : 4096;
+        for (int i = 0; i < to_read; i++) {
+            iq_buffer[i] = ctx->rx_modem_buffer[ctx->rx_modem_buffer_read_idx];
+            ctx->rx_modem_buffer_read_idx = (ctx->rx_modem_buffer_read_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
+        }
+        pthread_mutex_unlock(&ctx->rx_mutex);
+        
+        // Write to pipeline
+        ssize_t written = write(write_fd, iq_buffer, to_read * sizeof(float));
+        if (written < 0 && errno != EAGAIN) {
+            fprintf(stderr, "RADAE RX: Write error: %s\n", strerror(errno));
+            break;
+        }
+        
+    read_output_rx:
+        // Try to read speech output (16-bit PCM)
+        ssize_t bytes_read = read(read_fd, pcm_buffer, sizeof(pcm_buffer));
+        if (bytes_read > 0) {
+            int n_samples = bytes_read / sizeof(int16_t);
+            
+            pthread_mutex_lock(&ctx->rx_mutex);
+            int free_space = BUFFER_FREE(ctx->rx_speech_buffer_write_idx, 
+                                          ctx->rx_speech_buffer_read_idx, 
+                                          RADAE_SPEECH_BUFFER_SIZE);
+            int to_write = (n_samples < free_space) ? n_samples : free_space;
+            
+            for (int i = 0; i < to_write; i++) {
+                ctx->rx_speech_buffer[ctx->rx_speech_buffer_write_idx] = (float)pcm_buffer[i] / 32768.0f;
+                ctx->rx_speech_buffer_write_idx = (ctx->rx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
+            }
+            pthread_mutex_unlock(&ctx->rx_mutex);
+        }
+    }
+    
+    close(write_fd);
+    close(read_fd);
+    
+    waitpid(pid, NULL, 0);
+    ctx->rx_decoder_pid = 0;
+    
+    fprintf(stderr, "RADAE RX: Thread exiting\n");
+    return NULL;
+}
+
+// Sample rate conversion utilities
+
+// Simple linear interpolation resampler
+static void resample_linear(const double *in, int in_len, double *out, int out_len)
+{
+    if (in_len <= 1 || out_len <= 1) return;
+    
+    double ratio = (double)(in_len - 1) / (double)(out_len - 1);
+    
+    for (int i = 0; i < out_len; i++) {
+        double pos = i * ratio;
+        int idx = (int)pos;
+        double frac = pos - idx;
+        
+        if (idx >= in_len - 1) {
+            out[i] = in[in_len - 1];
+        } else {
+            out[i] = in[idx] * (1.0 - frac) + in[idx + 1] * frac;
+        }
+    }
+}
+
+void resample_96k_to_16k(const double *in, int in_len, float *out, int *out_len)
+{
+    // 96kHz to 16kHz = 6:1 decimation
+    *out_len = in_len / 6;
+    double temp[*out_len];
+    resample_linear(in, in_len, temp, *out_len);
+    for (int i = 0; i < *out_len; i++) {
+        out[i] = (float)temp[i];
+    }
+}
+
+void resample_16k_to_96k(const float *in, int in_len, double *out, int *out_len)
+{
+    // 16kHz to 96kHz = 1:6 interpolation
+    *out_len = in_len * 6;
+    double temp[in_len];
+    for (int i = 0; i < in_len; i++) {
+        temp[i] = (double)in[i];
+    }
+    resample_linear(temp, in_len, out, *out_len);
+}
+
+void resample_48k_to_16k(const double *in, int in_len, float *out, int *out_len)
+{
+    // 48kHz to 16kHz = 3:1 decimation
+    *out_len = in_len / 3;
+    double temp[*out_len];
+    resample_linear(in, in_len, temp, *out_len);
+    for (int i = 0; i < *out_len; i++) {
+        out[i] = (float)temp[i];
+    }
+}
+
+void resample_96k_to_8k(const double *in, int in_len, float *out, int *out_len)
+{
+    // 96kHz to 8kHz = 12:1 decimation
+    *out_len = in_len / 12;
+    double temp[*out_len];
+    resample_linear(in, in_len, temp, *out_len);
+    for (int i = 0; i < *out_len; i++) {
+        out[i] = (float)temp[i];
+    }
+}
+
+void resample_8k_to_96k(const float *in, int in_len, double *out, int *out_len)
+{
+    // 8kHz to 96kHz = 1:12 interpolation
+    *out_len = in_len * 12;
+    double temp[in_len];
+    for (int i = 0; i < in_len; i++) {
+        temp[i] = (double)in[i];
+    }
+    resample_linear(temp, in_len, out, *out_len);
+}

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -138,10 +138,22 @@ bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir)
         fprintf(stderr, "RADAE: debug logging enabled\n");
     }
 
+    // Start the persistent TX thread.  The thread forks the python
+    // pipeline, pre-warms it (torch + numpy imports, model load, first
+    // inference JIT) in the background, then sits idle until PTT.  See
+    // radae_tx_thread for the gating on ctx->tx_running.
+    ctx->tx_running = false;
+    if (pthread_create(&ctx->tx_thread, NULL, radae_tx_thread, ctx) != 0) {
+        fprintf(stderr, "RADAE: Failed to create TX thread\n");
+        goto cleanup_rx_speech;
+    }
+
     fprintf(stderr, "RADAE: Initialized with radae_dir=%s\n", ctx->radae_dir);
 
     return true;
 
+cleanup_rx_speech:
+    free(ctx->rx_speech_buffer);
 cleanup_rx_modem:
     free(ctx->rx_modem_buffer);
 cleanup_tx_modem:
@@ -160,71 +172,74 @@ void radae_shutdown(radae_context *ctx)
 {
     if (!ctx->initialized)
         return;
-    
+
     ctx->shutdown_requested = true;
-    
-    // Stop TX and RX if running
+
+    // Flip flow-control flags first so the threads observe shutdown
+    // on their next loop iteration.
     radae_tx_stop(ctx);
     radae_rx_stop(ctx);
-    
-    // Cleanup
+
+    // Tear down the persistent TX pipeline: kill the subprocess, then
+    // join the thread.  The thread's own cleanup path waitpid()s, so
+    // the SIGTERM is a belt-and-suspenders for the case where Python
+    // is stuck (e.g. blocked on read with no EOF yet).
+    pthread_cond_signal(&ctx->tx_cond);
+    if (ctx->tx_encoder_pid > 0) {
+        kill(ctx->tx_encoder_pid, SIGTERM);
+    }
+    pthread_join(ctx->tx_thread, NULL);
+
     pthread_mutex_destroy(&ctx->tx_mutex);
     pthread_mutex_destroy(&ctx->rx_mutex);
     pthread_cond_destroy(&ctx->tx_cond);
     pthread_cond_destroy(&ctx->rx_cond);
-    
+
     free(ctx->tx_speech_buffer);
     free(ctx->tx_modem_buffer);
     free(ctx->rx_modem_buffer);
     free(ctx->rx_speech_buffer);
-    
+
     ctx->initialized = false;
     fprintf(stderr, "RADAE: Shutdown complete\n");
 }
 
+// Flow-control only.  The TX thread and Python subprocess were started
+// at radae_init time and stay alive for the service lifetime; this
+// function just resets the ring buffers and flips the gating flag so
+// radae_tx_write_speech / radae_tx_read_modem_iq begin accepting
+// samples.  The ring-buffer reset is essential — without it, stale IQ
+// from the end of a prior PTT could play at the start of the next one.
 bool radae_tx_start(radae_context *ctx)
 {
     if (!ctx->initialized || ctx->tx_running)
         return false;
-    
-    ctx->tx_running = true;
+
+    pthread_mutex_lock(&ctx->tx_mutex);
     ctx->tx_speech_buffer_write_idx = 0;
-    ctx->tx_speech_buffer_read_idx = 0;
-    ctx->tx_modem_buffer_write_idx = 0;
-    ctx->tx_modem_buffer_read_idx = 0;
-    
-    // Start TX processing thread
-    if (pthread_create(&ctx->tx_thread, NULL, radae_tx_thread, ctx) != 0) {
-        fprintf(stderr, "RADAE: Failed to create TX thread\n");
-        ctx->tx_running = false;
-        return false;
-    }
-    
-    fprintf(stderr, "RADAE TX: Started\n");
+    ctx->tx_speech_buffer_read_idx  = 0;
+    ctx->tx_modem_buffer_write_idx  = 0;
+    ctx->tx_modem_buffer_read_idx   = 0;
+    ctx->tx_running = true;
+    pthread_cond_signal(&ctx->tx_cond);
+    pthread_mutex_unlock(&ctx->tx_mutex);
+
+    fprintf(stderr, "RADAE TX: flow enabled\n");
     return true;
 }
 
+// Flow-control only.  Leave the Python subprocess and TX thread alive
+// so the next PTT can start producing IQ within one modem frame
+// instead of re-paying the ~6 s torch/numpy/JIT warmup.  Teardown is
+// handled in radae_shutdown.
 void radae_tx_stop(radae_context *ctx)
 {
     if (!ctx->tx_running)
         return;
-    
+
     ctx->tx_running = false;
-    
-    // Signal the thread to wake up
     pthread_cond_signal(&ctx->tx_cond);
-    
-    // Wait for thread to finish
-    pthread_join(ctx->tx_thread, NULL);
-    
-    // Kill any subprocess
-    if (ctx->tx_encoder_pid > 0) {
-        kill(ctx->tx_encoder_pid, SIGTERM);
-        waitpid(ctx->tx_encoder_pid, NULL, 0);
-        ctx->tx_encoder_pid = 0;
-    }
-    
-    fprintf(stderr, "RADAE TX: Stopped\n");
+    fprintf(stderr, "RADAE TX: flow disabled\n");
 }
 
 bool radae_rx_start(radae_context *ctx)
@@ -381,11 +396,18 @@ static void *radae_tx_thread(void *arg)
     // Build command for TX pipeline
     // RADEv2: lpcnet_demo -features -> radae_txe2.py -> IQ samples
 
+    // stdbuf -o0 forces lpcnet_demo's stdout to be unbuffered.  When glibc
+    // detects a non-TTY (i.e. a pipe), it defaults stdout to full block
+    // buffering (~64 KiB).  At ~14.4 KiB/s of feature data that means ~4.5 s
+    // of silence from the Python script after PTT — observed as "py stdout
+    // STARVED 6.35s" with out/in=0.0032 after a 10 s key-down.
+    // python3 -u is defensive; the script already calls stdout.flush() each
+    // frame but -u guarantees unbuffered I/O in all future code paths.
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
-             "build/src/lpcnet_demo -features - - | "
-             "python3 radae_txe2.py --model_name %s",
+             "stdbuf -o0 build/src/lpcnet_demo -features - - | "
+             "python3 -u radae_txe2.py --model_name %s",
              ctx->radae_dir,
              RADAE_MODEL_PATH);
     
@@ -434,24 +456,129 @@ static void *radae_tx_thread(void *arg)
     // Parent process
     close(stdin_pipe[0]);  // Close read end of stdin pipe
     close(stdout_pipe[1]); // Close write end of stdout pipe
-    
+
     ctx->tx_encoder_pid = pid;
-    
+
     int write_fd = stdin_pipe[1];
     int read_fd = stdout_pipe[0];
-    
+
     // Set non-blocking on read
     int flags = fcntl(read_fd, F_GETFL, 0);
     fcntl(read_fd, F_SETFL, flags | O_NONBLOCK);
-    
+
     // Buffer for reading speech and writing to pipe (16-bit PCM)
     int16_t pcm_buffer[RADAE_FRAME_SIZE];
     float speech_buffer[RADAE_FRAME_SIZE];
-    
+
     // Buffer for reading IQ from pipe
     float iq_buffer[4096];
 
-    while (ctx->tx_running && !ctx->shutdown_requested) {
+    // Starvation detector for the Python pipeline's stdout.
+    // We report once when stdout has been silent for >STARVE_THRESH_S
+    // and once again when it resumes.  Cumulative totals make the ratio
+    // between input (speech) and output (IQ) visible at a glance.
+    // With the persistent-pipeline refactor, the only STARVED event we
+    // expect to see is during the init-time warmup below — every PTT
+    // thereafter should produce IQ within one modem frame.
+    const double STARVE_THRESH_S = 0.5;
+    struct timespec tx_start_t;
+    clock_gettime(CLOCK_MONOTONIC, &tx_start_t);
+    struct timespec tx_out_last_t = tx_start_t;
+    bool tx_starved = false;
+    uint64_t tx_in_samp_total   = 0;
+    uint64_t tx_out_csamp_total = 0;
+
+    // Pre-warm: amortize the ~6 s torch + numpy import + model load +
+    // first-inference JIT cost *before* the first PTT.  Feed 1 s of
+    // zero-valued 16 kHz PCM, read and discard the resulting IQ, then
+    // drop through to the main loop where tx_running gates everything.
+    // Writes are blocking and Python only reads ~16 kB/s while the
+    // first inference is still compiling, so the pipe buffer
+    // back-pressures us — that's fine, we run in the background while
+    // the rest of sbitx finishes initializing.
+    {
+        fprintf(stderr, "RADAE TX: pre-warming python pipeline...\n");
+        int16_t warm_pcm[RADAE_FRAME_SIZE];
+        memset(warm_pcm, 0, sizeof(warm_pcm));
+        const int warmup_frames = 100; // 100 * 10 ms = 1 s of silence
+        struct timespec warm_t0;
+        clock_gettime(CLOCK_MONOTONIC, &warm_t0);
+        for (int i = 0; i < warmup_frames && !ctx->shutdown_requested; i++) {
+            ssize_t w = write(write_fd, warm_pcm, sizeof(warm_pcm));
+            (void)w;
+            // Drain whatever IQ has come out so far to keep the
+            // stdout pipe empty and avoid back-pressuring Python.
+            while (read(read_fd, iq_buffer, sizeof(iq_buffer)) > 0) {}
+        }
+        // Wait up to 15 s for the first output frame — this is the
+        // signal that JIT is complete.
+        bool warm_ok = false;
+        struct timespec t_deadline = warm_t0;
+        t_deadline.tv_sec += 15;
+        while (!ctx->shutdown_requested) {
+            ssize_t n = read(read_fd, iq_buffer, sizeof(iq_buffer));
+            if (n > 0) { warm_ok = true; break; }
+            struct timespec now;
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            if (now.tv_sec > t_deadline.tv_sec) break;
+            struct timespec slp = {0, 10 * 1000 * 1000}; // 10 ms
+            nanosleep(&slp, NULL);
+        }
+        // Drain anything else that accumulated.
+        while (read(read_fd, iq_buffer, sizeof(iq_buffer)) > 0) {}
+        struct timespec warm_t1;
+        clock_gettime(CLOCK_MONOTONIC, &warm_t1);
+        double warm_dt = (warm_t1.tv_sec  - warm_t0.tv_sec) +
+                         (warm_t1.tv_nsec - warm_t0.tv_nsec) / 1e9;
+        fprintf(stderr, "RADAE TX: warmup %s in %.2fs\n",
+                warm_ok ? "complete" : "timed out (check logs)", warm_dt);
+        // Reset the starvation clock so the warmup itself doesn't
+        // trigger a STARVED event once the main loop starts.
+        clock_gettime(CLOCK_MONOTONIC, &tx_out_last_t);
+        tx_starved = false;
+        tx_in_samp_total   = 0;
+        tx_out_csamp_total = 0;
+    }
+
+    while (!ctx->shutdown_requested) {
+        // Idle branch: PTT is off (or DV mode just got disabled).
+        // Don't feed python; don't write to the modem buffer.  Drain
+        // any stale IQ so it doesn't leak into the next key-down, and
+        // keep tx_out_last_t fresh so the starvation detector doesn't
+        // fire spuriously while we wait.
+        if (!ctx->tx_running) {
+            while (read(read_fd, iq_buffer, sizeof(iq_buffer)) > 0) {}
+            clock_gettime(CLOCK_MONOTONIC, &tx_out_last_t);
+            tx_starved = false;
+            pthread_mutex_lock(&ctx->tx_mutex);
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_nsec += 50 * 1000 * 1000; // 50 ms
+            if (ts.tv_nsec >= 1000000000) { ts.tv_sec++; ts.tv_nsec -= 1000000000; }
+            pthread_cond_timedwait(&ctx->tx_cond, &ctx->tx_mutex, &ts);
+            pthread_mutex_unlock(&ctx->tx_mutex);
+            continue;
+        }
+
+        // Once per iteration, check for stdout starvation.
+        if (radae_debug && !tx_starved) {
+            struct timespec _now;
+            clock_gettime(CLOCK_MONOTONIC, &_now);
+            double silence = (_now.tv_sec  - tx_out_last_t.tv_sec) +
+                             (_now.tv_nsec - tx_out_last_t.tv_nsec) / 1e9;
+            if (silence > STARVE_THRESH_S) {
+                fprintf(stderr,
+                    "RADAE TX: py stdout STARVED %.2fs silent "
+                    "(in=%llu samp, out=%llu csamp, ratio out/in=%.4f)\n",
+                    silence,
+                    (unsigned long long)tx_in_samp_total,
+                    (unsigned long long)tx_out_csamp_total,
+                    tx_in_samp_total ?
+                      (double)tx_out_csamp_total / (double)tx_in_samp_total : 0.0);
+                tx_starved = true;
+            }
+        }
+
         // Check for speech data in buffer
         pthread_mutex_lock(&ctx->tx_mutex);
         int available = BUFFER_SIZE(ctx->tx_speech_buffer_write_idx, 
@@ -496,6 +623,7 @@ static void *radae_tx_thread(void *arg)
             break;
         }
         if (written > 0) {
+            tx_in_samp_total += (uint64_t)(written / sizeof(int16_t));
             RADAE_RATE_LOG("tx_py_stdin  ctx->py",  "samp",
                            (int)(written / sizeof(int16_t)), "16000 samp/s");
         }
@@ -505,18 +633,39 @@ static void *radae_tx_thread(void *arg)
         ssize_t bytes_read = read(read_fd, iq_buffer, sizeof(iq_buffer));
         if (bytes_read > 0) {
             int n_floats = bytes_read / sizeof(float);
-            
+
             pthread_mutex_lock(&ctx->tx_mutex);
-            int free_space = BUFFER_FREE(ctx->tx_modem_buffer_write_idx, 
-                                          ctx->tx_modem_buffer_read_idx, 
+            int free_space = BUFFER_FREE(ctx->tx_modem_buffer_write_idx,
+                                          ctx->tx_modem_buffer_read_idx,
                                           RADAE_MODEM_BUFFER_SIZE * 2);
             int to_write = (n_floats < free_space) ? n_floats : free_space;
-            
+
             for (int i = 0; i < to_write; i++) {
                 ctx->tx_modem_buffer[ctx->tx_modem_buffer_write_idx] = iq_buffer[i];
                 ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
             }
             pthread_mutex_unlock(&ctx->tx_mutex);
+
+            // Starvation bookkeeping: update cumulative totals and last-seen
+            // timestamp; if we were previously starved, announce recovery.
+            tx_out_csamp_total += (uint64_t)(n_floats / 2);
+            struct timespec _now;
+            clock_gettime(CLOCK_MONOTONIC, &_now);
+            if (tx_starved) {
+                double silence = (_now.tv_sec  - tx_out_last_t.tv_sec) +
+                                 (_now.tv_nsec - tx_out_last_t.tv_nsec) / 1e9;
+                fprintf(stderr,
+                    "RADAE TX: py stdout RESUMED after %.2fs "
+                    "(in=%llu samp, out=%llu csamp, ratio out/in=%.4f)\n",
+                    silence,
+                    (unsigned long long)tx_in_samp_total,
+                    (unsigned long long)tx_out_csamp_total,
+                    tx_in_samp_total ?
+                      (double)tx_out_csamp_total / (double)tx_in_samp_total : 0.0);
+                tx_starved = false;
+            }
+            tx_out_last_t = _now;
+
             // n_floats is interleaved I/Q, so csamp count = n_floats/2
             RADAE_RATE_LOG("tx_py_stdout py->ctx",  "csamp",
                            n_floats / 2, "8000 csamp/s");
@@ -529,7 +678,25 @@ static void *radae_tx_thread(void *arg)
     // Wait for child process
     waitpid(pid, NULL, 0);
     ctx->tx_encoder_pid = 0;
-    
+
+    if (radae_debug) {
+        struct timespec _now;
+        clock_gettime(CLOCK_MONOTONIC, &_now);
+        double elapsed = (_now.tv_sec  - tx_start_t.tv_sec) +
+                         (_now.tv_nsec - tx_start_t.tv_nsec) / 1e9;
+        // Expected ratio: 8000 csamp out / 16000 samp in = 0.5
+        fprintf(stderr,
+            "RADAE TX: summary %.2fs elapsed, in=%llu samp (%.0f/s), "
+            "out=%llu csamp (%.0f/s), ratio out/in=%.4f (expect 0.5)\n",
+            elapsed,
+            (unsigned long long)tx_in_samp_total,
+            elapsed > 0 ? (double)tx_in_samp_total / elapsed : 0.0,
+            (unsigned long long)tx_out_csamp_total,
+            elapsed > 0 ? (double)tx_out_csamp_total / elapsed : 0.0,
+            tx_in_samp_total ?
+              (double)tx_out_csamp_total / (double)tx_in_samp_total : 0.0);
+    }
+
     fprintf(stderr, "RADAE TX: Thread exiting\n");
     return NULL;
 }
@@ -542,11 +709,14 @@ static void *radae_rx_thread(void *arg)
     
     // RADEv2 RX pipeline: IQ samples -> radae_rxe2.py -> features -> lpcnet_demo -fargan-synthesis
 
+    // Same stdio-buffering workaround as TX: lpcnet_demo's stdout is fully
+    // buffered when piped, delaying audio arrival by up to the buffer size.
+    // -u on Python is defensive; radae_rxe2.py already flushes per write.
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
-             "python3 radae_rxe2.py --model_name %s --frame_sync_model_name %s | "
-             "build/src/lpcnet_demo -fargan-synthesis - -",
+             "python3 -u radae_rxe2.py --model_name %s --frame_sync_model_name %s | "
+             "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
              ctx->radae_dir,
              RADAE_MODEL_PATH,
              RADAE_SYNC_MODEL_PATH);

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -34,6 +34,8 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <math.h>
+#include <time.h>
+#include <stdint.h>
 
 #include "sbitx_core.h"
 #include "sbitx_radae.h"
@@ -46,6 +48,35 @@ static int radae_debug = 0;
 
 #define BUFFER_FREE(write_idx, read_idx, max_size) \
     ((max_size) - 1 - BUFFER_SIZE(write_idx, read_idx, max_size))
+
+// Sample-rate instrumentation: accumulates counts and prints once per second to
+// stderr when radae_debug is on. `tag` is a literal string identifying the
+// measurement point, `units` is a literal string naming what `n` counts
+// (e.g. "samp", "csamp", "B"), `expect` is the nominal rate shown alongside
+// the measured one so drift is obvious at a glance.
+#define RADAE_RATE_LOG(tag, units, n, expect) do {                             \
+    if (radae_debug) {                                                         \
+        static uint64_t _st_count = 0;                                         \
+        static uint64_t _st_calls = 0;                                         \
+        static struct timespec _st_t0 = {0, 0};                                \
+        struct timespec _st_now;                                               \
+        clock_gettime(CLOCK_MONOTONIC, &_st_now);                              \
+        if (_st_t0.tv_sec == 0 && _st_t0.tv_nsec == 0) _st_t0 = _st_now;       \
+        _st_count += (uint64_t)(n);                                            \
+        _st_calls += 1;                                                        \
+        double _st_dt = (_st_now.tv_sec  - _st_t0.tv_sec) +                    \
+                        (_st_now.tv_nsec - _st_t0.tv_nsec) / 1e9;              \
+        if (_st_dt >= 1.0) {                                                   \
+            fprintf(stderr,                                                    \
+                "RADAE rate [%s]: %.0f %s/s (%.1f call/s, expect %s)\n",       \
+                (tag), (double)_st_count/_st_dt, (units),                      \
+                (double)_st_calls/_st_dt, (expect));                           \
+            _st_count = 0;                                                     \
+            _st_calls = 0;                                                     \
+            _st_t0    = _st_now;                                               \
+        }                                                                      \
+    }                                                                          \
+} while (0)
 
 // TX thread: reads from speech buffer, writes to modem buffer via RADAE pipeline
 static void *radae_tx_thread(void *arg);
@@ -255,10 +286,12 @@ int radae_tx_write_speech(radae_context *ctx, const float *samples, int n_sample
         ctx->tx_speech_buffer[ctx->tx_speech_buffer_write_idx] = samples[i];
         ctx->tx_speech_buffer_write_idx = (ctx->tx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
     }
-    
+
     pthread_cond_signal(&ctx->tx_cond);
     pthread_mutex_unlock(&ctx->tx_mutex);
-    
+
+    RADAE_RATE_LOG("tx_in  radio->ctx", "samp", to_write, "16000 samp/s");
+
     return to_write;
 }
 
@@ -279,9 +312,11 @@ int radae_tx_read_modem_iq(radae_context *ctx, float *iq_samples, int max_sample
         iq_samples[i] = ctx->tx_modem_buffer[ctx->tx_modem_buffer_read_idx];
         ctx->tx_modem_buffer_read_idx = (ctx->tx_modem_buffer_read_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
     }
-    
+
     pthread_mutex_unlock(&ctx->tx_mutex);
-    
+
+    RADAE_RATE_LOG("tx_out ctx->radio", "csamp", to_read, "8000 csamp/s");
+
     return to_read;
 }
 
@@ -302,10 +337,12 @@ int radae_rx_write_modem_iq(radae_context *ctx, const float *iq_samples, int n_s
         ctx->rx_modem_buffer[ctx->rx_modem_buffer_write_idx] = iq_samples[i];
         ctx->rx_modem_buffer_write_idx = (ctx->rx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
     }
-    
+
     pthread_cond_signal(&ctx->rx_cond);
     pthread_mutex_unlock(&ctx->rx_mutex);
-    
+
+    RADAE_RATE_LOG("rx_in  radio->ctx", "csamp", to_write, "8000 csamp/s");
+
     return to_write;
 }
 
@@ -325,9 +362,11 @@ int radae_rx_read_speech(radae_context *ctx, float *samples, int max_samples)
         samples[i] = ctx->rx_speech_buffer[ctx->rx_speech_buffer_read_idx];
         ctx->rx_speech_buffer_read_idx = (ctx->rx_speech_buffer_read_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
     }
-    
+
     pthread_mutex_unlock(&ctx->rx_mutex);
-    
+
+    RADAE_RATE_LOG("rx_out ctx->radio", "samp", to_read, "16000 samp/s");
+
     return to_read;
 }
 
@@ -410,11 +449,6 @@ static void *radae_tx_thread(void *arg)
     // Buffer for reading IQ from pipe
     float iq_buffer[4096];
 
-    // Rate-limit per-loop debug prints so RADAE_DEBUG=1 doesn't flood stderr.
-    // One line every DBG_PERIOD iterations (~2s at RADAE_FRAME_SIZE=160 @ 16kHz).
-    const int DBG_PERIOD = 200;
-    int dbg_wr_count = 0, dbg_rd_count = 0;
-
     while (ctx->tx_running && !ctx->shutdown_requested) {
         // Check for speech data in buffer
         pthread_mutex_lock(&ctx->tx_mutex);
@@ -459,9 +493,9 @@ static void *radae_tx_thread(void *arg)
             fprintf(stderr, "RADAE TX: Write error: %s\n", strerror(errno));
             break;
         }
-        if (written >= 0 && radae_debug && (dbg_wr_count++ % DBG_PERIOD) == 0) {
-            fprintf(stderr, "RADAE TX: wrote %zd bytes to encoder stdin (%zd frames) [every %d]\n",
-                    written, written / sizeof(int16_t), DBG_PERIOD);
+        if (written > 0) {
+            RADAE_RATE_LOG("tx_py_stdin  ctx->py",  "samp",
+                           (int)(written / sizeof(int16_t)), "16000 samp/s");
         }
 
     read_output:
@@ -481,10 +515,9 @@ static void *radae_tx_thread(void *arg)
                 ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
             }
             pthread_mutex_unlock(&ctx->tx_mutex);
-            if (radae_debug && (dbg_rd_count++ % DBG_PERIOD) == 0) {
-                fprintf(stderr, "RADAE TX: read %zd bytes (%d floats) from encoder stdout, wrote %d floats to tx_modem_buffer (free %d) [every %d]\n",
-                        bytes_read, n_floats, to_write, free_space, DBG_PERIOD);
-            }
+            // n_floats is interleaved I/Q, so csamp count = n_floats/2
+            RADAE_RATE_LOG("tx_py_stdout py->ctx",  "csamp",
+                           n_floats / 2, "8000 csamp/s");
         }
     }
 
@@ -574,10 +607,6 @@ static void *radae_rx_thread(void *arg)
     float iq_buffer[4096];
     int16_t pcm_buffer[2048];
 
-    // Rate-limit per-loop debug prints (see TX thread for rationale).
-    const int DBG_PERIOD = 200;
-    int dbg_wr_count = 0, dbg_rd_count = 0;
-
     while (ctx->rx_running && !ctx->shutdown_requested) {
         // Check for modem IQ data in buffer
         pthread_mutex_lock(&ctx->rx_mutex);
@@ -614,9 +643,10 @@ static void *radae_rx_thread(void *arg)
             fprintf(stderr, "RADAE RX: Write error: %s\n", strerror(errno));
             break;
         }
-        if (written >= 0 && radae_debug && (dbg_wr_count++ % DBG_PERIOD) == 0) {
-            fprintf(stderr, "RADAE RX: wrote %zd bytes to decoder stdin (%zd floats) [every %d]\n",
-                    written, written / sizeof(float), DBG_PERIOD);
+        if (written > 0) {
+            // iq_buffer is interleaved I/Q floats, so csamp count = floats/2
+            RADAE_RATE_LOG("rx_py_stdin  ctx->py",  "csamp",
+                           (int)(written / sizeof(float)) / 2, "8000 csamp/s");
         }
 
     read_output_rx:
@@ -636,16 +666,14 @@ static void *radae_rx_thread(void *arg)
                 ctx->rx_speech_buffer_write_idx = (ctx->rx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
             }
             pthread_mutex_unlock(&ctx->rx_mutex);
-            if (radae_debug && (dbg_rd_count++ % DBG_PERIOD) == 0) {
-                fprintf(stderr, "RADAE RX: read %zd bytes (%d samples) from decoder stdout, wrote %d samples to rx_speech_buffer (free %d) [every %d]\n",
-                        bytes_read, n_samples, to_write, free_space, DBG_PERIOD);
-            }
+            RADAE_RATE_LOG("rx_py_stdout py->ctx", "samp",
+                           n_samples, "16000 samp/s (when synced)");
         }
     }
-    
+
     close(write_fd);
     close(read_fd);
-    
+
     waitpid(pid, NULL, 0);
     ctx->rx_decoder_pid = 0;
     

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -37,6 +37,8 @@
 
 #include "sbitx_core.h"
 #include "sbitx_radae.h"
+/* Enable verbose debug logging when RADAE_DEBUG env var is set to 1 or true */
+static int radae_debug = 0;
 
 // Helper macros for circular buffer operations
 #define BUFFER_SIZE(write_idx, read_idx, max_size) \
@@ -95,9 +97,16 @@ bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir)
     
     ctx->initialized = true;
     ctx->shutdown_requested = false;
-    
+
+    /* enable runtime debug logging if requested */
+    char *dbg = getenv("RADAE_DEBUG");
+    if (dbg && (strcmp(dbg, "1") == 0 || dbg[0] == 't' || dbg[0] == 'T')) {
+        radae_debug = 1;
+        fprintf(stderr, "RADAE: debug logging enabled\n");
+    }
+
     fprintf(stderr, "RADAE: Initialized with radae_dir=%s\n", ctx->radae_dir);
-    
+
     return true;
 
 cleanup_rx_modem:
@@ -147,6 +156,7 @@ bool radae_tx_start(radae_context *ctx)
     
     ctx->tx_running = true;
     ctx->tx_speech_buffer_write_idx = 0;
+            if (radae_debug) fprintf(stderr, "RADAE TX: debug enabled\n");
     ctx->tx_speech_buffer_read_idx = 0;
     ctx->tx_modem_buffer_write_idx = 0;
     ctx->tx_modem_buffer_read_idx = 0;
@@ -340,6 +350,7 @@ static void *radae_tx_thread(void *arg)
              RADAE_MODEL_PATH);
     
     fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
+    if (radae_debug) fprintf(stderr, "RADAE TX: debug enabled\n");
     
     // Create pipes for stdin and stdout
     int stdin_pipe[2], stdout_pipe[2];
@@ -444,6 +455,9 @@ static void *radae_tx_thread(void *arg)
             fprintf(stderr, "RADAE TX: Write error: %s\n", strerror(errno));
             break;
         }
+        if (written >= 0 && radae_debug) {
+            fprintf(stderr, "RADAE TX: wrote %zd bytes to encoder stdin (%zd frames)\n", written, written / sizeof(int16_t));
+        }
         
     read_output:
         // Try to read modem IQ output
@@ -462,6 +476,9 @@ static void *radae_tx_thread(void *arg)
                 ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
             }
             pthread_mutex_unlock(&ctx->tx_mutex);
+            if (radae_debug) {
+                fprintf(stderr, "RADAE TX: read %zd bytes (%d floats) from encoder stdout, wrote %d floats to tx_modem_buffer (free %d)\n", bytes_read, n_floats, to_write, free_space);
+            }
         }
     }
     
@@ -493,6 +510,7 @@ static void *radae_rx_thread(void *arg)
              RADAE_MODEL_PATH);
     
     fprintf(stderr, "RADAE RX: Starting pipeline: %s\n", cmd);
+    if (radae_debug) fprintf(stderr, "RADAE RX: debug enabled\n");
     
     // Create pipes for stdin and stdout
     int stdin_pipe[2], stdout_pipe[2];
@@ -585,6 +603,9 @@ static void *radae_rx_thread(void *arg)
             fprintf(stderr, "RADAE RX: Write error: %s\n", strerror(errno));
             break;
         }
+        if (written >= 0 && radae_debug) {
+            fprintf(stderr, "RADAE RX: wrote %zd bytes to decoder stdin (%zd floats)\n", written, written / sizeof(float));
+        }
         
     read_output_rx:
         // Try to read speech output (16-bit PCM)
@@ -603,6 +624,9 @@ static void *radae_rx_thread(void *arg)
                 ctx->rx_speech_buffer_write_idx = (ctx->rx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
             }
             pthread_mutex_unlock(&ctx->rx_mutex);
+            if (radae_debug) {
+                fprintf(stderr, "RADAE RX: read %zd bytes (%d samples) from decoder stdout, wrote %d samples to rx_speech_buffer (free %d)\n", bytes_read, n_samples, to_write, free_space);
+            }
         }
     }
     

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -42,6 +42,8 @@
 /* Enable verbose debug logging when RADAE_DEBUG env var is set to 1 or true */
 static int radae_debug = 0;
 
+bool radae_is_debug(void) { return radae_debug != 0; }
+
 // Helper macros for circular buffer operations
 #define BUFFER_SIZE(write_idx, read_idx, max_size) \
     (((write_idx) - (read_idx) + (max_size)) % (max_size))

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -344,7 +344,7 @@ static void *radae_tx_thread(void *arg)
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
              "build/src/lpcnet_demo -features - - | "
-             "python3 radae_txe2.py --model_name %s 2>/dev/null",
+             "python3 radae_txe2.py --model_name %s",
              ctx->radae_dir,
              RADAE_MODEL_PATH);
     
@@ -510,8 +510,8 @@ static void *radae_rx_thread(void *arg)
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
-             "python3 radae_rxe2.py --model_name %s --frame_sync_model_name %s 2>/dev/null | "
-             "build/src/lpcnet_demo -fargan-synthesis - - 2>/dev/null",
+             "python3 radae_rxe2.py --model_name %s --frame_sync_model_name %s | "
+             "build/src/lpcnet_demo -fargan-synthesis - -",
              ctx->radae_dir,
              RADAE_MODEL_PATH,
              RADAE_SYNC_MODEL_PATH);

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -156,7 +156,6 @@ bool radae_tx_start(radae_context *ctx)
     
     ctx->tx_running = true;
     ctx->tx_speech_buffer_write_idx = 0;
-            if (radae_debug) fprintf(stderr, "RADAE TX: debug enabled\n");
     ctx->tx_speech_buffer_read_idx = 0;
     ctx->tx_modem_buffer_write_idx = 0;
     ctx->tx_modem_buffer_read_idx = 0;
@@ -410,7 +409,12 @@ static void *radae_tx_thread(void *arg)
     
     // Buffer for reading IQ from pipe
     float iq_buffer[4096];
-    
+
+    // Rate-limit per-loop debug prints so RADAE_DEBUG=1 doesn't flood stderr.
+    // One line every DBG_PERIOD iterations (~2s at RADAE_FRAME_SIZE=160 @ 16kHz).
+    const int DBG_PERIOD = 200;
+    int dbg_wr_count = 0, dbg_rd_count = 0;
+
     while (ctx->tx_running && !ctx->shutdown_requested) {
         // Check for speech data in buffer
         pthread_mutex_lock(&ctx->tx_mutex);
@@ -455,10 +459,11 @@ static void *radae_tx_thread(void *arg)
             fprintf(stderr, "RADAE TX: Write error: %s\n", strerror(errno));
             break;
         }
-        if (written >= 0 && radae_debug) {
-            fprintf(stderr, "RADAE TX: wrote %zd bytes to encoder stdin (%zd frames)\n", written, written / sizeof(int16_t));
+        if (written >= 0 && radae_debug && (dbg_wr_count++ % DBG_PERIOD) == 0) {
+            fprintf(stderr, "RADAE TX: wrote %zd bytes to encoder stdin (%zd frames) [every %d]\n",
+                    written, written / sizeof(int16_t), DBG_PERIOD);
         }
-        
+
     read_output:
         // Try to read modem IQ output
         ssize_t bytes_read = read(read_fd, iq_buffer, sizeof(iq_buffer));
@@ -476,15 +481,16 @@ static void *radae_tx_thread(void *arg)
                 ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
             }
             pthread_mutex_unlock(&ctx->tx_mutex);
-            if (radae_debug) {
-                fprintf(stderr, "RADAE TX: read %zd bytes (%d floats) from encoder stdout, wrote %d floats to tx_modem_buffer (free %d)\n", bytes_read, n_floats, to_write, free_space);
+            if (radae_debug && (dbg_rd_count++ % DBG_PERIOD) == 0) {
+                fprintf(stderr, "RADAE TX: read %zd bytes (%d floats) from encoder stdout, wrote %d floats to tx_modem_buffer (free %d) [every %d]\n",
+                        bytes_read, n_floats, to_write, free_space, DBG_PERIOD);
             }
         }
     }
-    
+
     close(write_fd);
     close(read_fd);
-    
+
     // Wait for child process
     waitpid(pid, NULL, 0);
     ctx->tx_encoder_pid = 0;
@@ -567,7 +573,11 @@ static void *radae_rx_thread(void *arg)
     
     float iq_buffer[4096];
     int16_t pcm_buffer[2048];
-    
+
+    // Rate-limit per-loop debug prints (see TX thread for rationale).
+    const int DBG_PERIOD = 200;
+    int dbg_wr_count = 0, dbg_rd_count = 0;
+
     while (ctx->rx_running && !ctx->shutdown_requested) {
         // Check for modem IQ data in buffer
         pthread_mutex_lock(&ctx->rx_mutex);
@@ -604,10 +614,11 @@ static void *radae_rx_thread(void *arg)
             fprintf(stderr, "RADAE RX: Write error: %s\n", strerror(errno));
             break;
         }
-        if (written >= 0 && radae_debug) {
-            fprintf(stderr, "RADAE RX: wrote %zd bytes to decoder stdin (%zd floats)\n", written, written / sizeof(float));
+        if (written >= 0 && radae_debug && (dbg_wr_count++ % DBG_PERIOD) == 0) {
+            fprintf(stderr, "RADAE RX: wrote %zd bytes to decoder stdin (%zd floats) [every %d]\n",
+                    written, written / sizeof(float), DBG_PERIOD);
         }
-        
+
     read_output_rx:
         // Try to read speech output (16-bit PCM)
         ssize_t bytes_read = read(read_fd, pcm_buffer, sizeof(pcm_buffer));
@@ -625,8 +636,9 @@ static void *radae_rx_thread(void *arg)
                 ctx->rx_speech_buffer_write_idx = (ctx->rx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
             }
             pthread_mutex_unlock(&ctx->rx_mutex);
-            if (radae_debug) {
-                fprintf(stderr, "RADAE RX: read %zd bytes (%d samples) from decoder stdout, wrote %d samples to rx_speech_buffer (free %d)\n", bytes_read, n_samples, to_write, free_space);
+            if (radae_debug && (dbg_rd_count++ % DBG_PERIOD) == 0) {
+                fprintf(stderr, "RADAE RX: read %zd bytes (%d samples) from decoder stdout, wrote %d samples to rx_speech_buffer (free %d) [every %d]\n",
+                        bytes_read, n_samples, to_write, free_space, DBG_PERIOD);
             }
         }
     }

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -333,19 +333,19 @@ int radae_rx_read_speech(radae_context *ctx, float *samples, int max_samples)
 }
 
 // TX thread implementation
-// Pipeline: speech (16kHz) -> lpcnet_demo -features -> inference.py -> modem IQ (8kHz)
+// Pipeline: speech (16kHz) -> lpcnet_demo -features -> radae_txe2.py -> modem IQ (8kHz)
 static void *radae_tx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
     
     // Build command for TX pipeline
-    // RADEv2: lpcnet_demo -features -> radae_txe.py -> IQ samples
-    
+    // RADEv2: lpcnet_demo -features -> radae_txe2.py -> IQ samples
+
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
              "build/src/lpcnet_demo -features - - | "
-             "python3 radae_txe.py --model_name %s 2>/dev/null",
+             "python3 radae_txe2.py --model_name %s 2>/dev/null",
              ctx->radae_dir,
              RADAE_MODEL_PATH);
     
@@ -494,20 +494,21 @@ static void *radae_tx_thread(void *arg)
 }
 
 // RX thread implementation
-// Pipeline: modem IQ (8kHz) -> rx2.py -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
+// Pipeline: modem IQ (8kHz) -> radae_rxe2.py -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
 static void *radae_rx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
     
-    // RADEv2 RX pipeline: IQ samples -> radae_rxe.py -> features -> lpcnet_demo -fargan-synthesis
-    
+    // RADEv2 RX pipeline: IQ samples -> radae_rxe2.py -> features -> lpcnet_demo -fargan-synthesis
+
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
-             "python3 radae_rxe.py --model_name %s -v 0 | "
+             "python3 radae_rxe2.py --model_name %s --frame_sync_model_name %s 2>/dev/null | "
              "build/src/lpcnet_demo -fargan-synthesis - - 2>/dev/null",
              ctx->radae_dir,
-             RADAE_MODEL_PATH);
+             RADAE_MODEL_PATH,
+             RADAE_SYNC_MODEL_PATH);
     
     fprintf(stderr, "RADAE RX: Starting pipeline: %s\n", cmd);
     if (radae_debug) fprintf(stderr, "RADAE RX: debug enabled\n");

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -728,14 +728,18 @@ static void *radae_rx_thread(void *arg)
     // Same stdio-buffering workaround as TX: lpcnet_demo's stdout is fully
     // buffered when piped, delaying audio arrival by up to the buffer size.
     // -u on Python is defensive; radae_rxe2.py already flushes per write.
+    char verbose_arg[8] = "";
     char cmd[2048];
+    if (radae_is_debug())
+        strcpy(verbose_arg, " -v");
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
-             "python3 -u radae_rxe2.py --model_name %s --frame_sync_model_name %s | "
+             "python3 -u radae_rxe2.py --model_name %s --frame_sync_model_name %s%s | "
              "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
              ctx->radae_dir,
              RADAE_MODEL_PATH,
-             RADAE_SYNC_MODEL_PATH);
+             RADAE_SYNC_MODEL_PATH,
+             verbose_arg);
     
     fprintf(stderr, "RADAE RX: Starting pipeline: %s\n", cmd);
     if (radae_debug) fprintf(stderr, "RADAE RX: debug enabled\n");

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -246,7 +246,7 @@ void radae_tx_stop(radae_context *ctx)
 
 bool radae_tx_emit_eoo(radae_context *ctx)
 {
-    if (!ctx || !ctx->initialized || ctx->tx_python_pid <= 1)
+    if (!ctx || !ctx->initialized || ctx->tx_encoder_eoo_pid <= 1)
         return false;
 
     // Prevent any queued speech/silence after PTT-off from being encoded
@@ -258,15 +258,15 @@ bool radae_tx_emit_eoo(radae_context *ctx)
     pthread_cond_signal(&ctx->tx_cond);
     pthread_mutex_unlock(&ctx->tx_mutex);
 
-    if (kill(ctx->tx_python_pid, SIGUSR1) != 0) {
-        fprintf(stderr, "RADAE TX: SIGUSR1 to python pid %d failed: %s\n",
-                (int)ctx->tx_python_pid, strerror(errno));
+    if (kill(ctx->tx_encoder_eoo_pid, SIGUSR1) != 0) {
+        fprintf(stderr, "RADAE TX: SIGUSR1 to encoder pid %d failed: %s\n",
+                (int)ctx->tx_encoder_eoo_pid, strerror(errno));
         ctx->tx_eoo_only = false;
         return false;
     }
     if (radae_debug)
         fprintf(stderr, "RADAE TX: EOO requested (SIGUSR1 -> %d)\n",
-                (int)ctx->tx_python_pid);
+                (int)ctx->tx_encoder_eoo_pid);
     return true;
 }
 
@@ -463,7 +463,7 @@ static void *radae_tx_thread(void *arg)
     // Remove any stale pidfile from a prior run so we don't read it and
     // signal a long-dead Python PID that may have been reassigned.
     unlink(RADAE_TX_PID_FILE);
-    ctx->tx_python_pid = 0;
+    ctx->tx_encoder_eoo_pid = 0;
 
     // Create pipes for stdin and stdout
     int stdin_pipe[2], stdout_pipe[2];
@@ -548,7 +548,7 @@ static void *radae_tx_thread(void *arg)
     // back-pressures us — that's fine, we run in the background while
     // the rest of sbitx finishes initializing.
     {
-        fprintf(stderr, "RADAE TX: pre-warming python pipeline...\n");
+        fprintf(stderr, "RADAE TX: pre-warming TX pipeline...\n");
         int16_t warm_pcm[RADAE_FRAME_SIZE];
         memset(warm_pcm, 0, sizeof(warm_pcm));
         const int warmup_frames = 100; // 100 * 10 ms = 1 s of silence
@@ -601,9 +601,9 @@ static void *radae_tx_thread(void *arg)
         if (pf) {
             int p = 0;
             if (fscanf(pf, "%d", &p) == 1 && p > 1) {
-                ctx->tx_python_pid = (pid_t)p;
-                fprintf(stderr, "RADAE TX: python pid %d (EOO signal target)\n",
-                        (int)ctx->tx_python_pid);
+                ctx->tx_encoder_eoo_pid = (pid_t)p;
+                fprintf(stderr, "RADAE TX: encoder pid %d (EOO signal target)\n",
+                        (int)ctx->tx_encoder_eoo_pid);
             }
             fclose(pf);
         } else {

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -220,6 +220,7 @@ bool radae_tx_start(radae_context *ctx)
     ctx->tx_speech_buffer_read_idx  = 0;
     ctx->tx_modem_buffer_write_idx  = 0;
     ctx->tx_modem_buffer_read_idx   = 0;
+    ctx->tx_eoo_only = false;
     ctx->tx_running = true;
     pthread_cond_signal(&ctx->tx_cond);
     pthread_mutex_unlock(&ctx->tx_mutex);
@@ -237,9 +238,36 @@ void radae_tx_stop(radae_context *ctx)
     if (!ctx->tx_running)
         return;
 
+    ctx->tx_eoo_only = false;
     ctx->tx_running = false;
     pthread_cond_signal(&ctx->tx_cond);
     fprintf(stderr, "RADAE TX: flow disabled\n");
+}
+
+bool radae_tx_emit_eoo(radae_context *ctx)
+{
+    if (!ctx || !ctx->initialized || ctx->tx_python_pid <= 1)
+        return false;
+
+    // Prevent any queued speech/silence after PTT-off from being encoded
+    // after the EOO frame. From this point until tr_switch finishes, the
+    // TX thread should only drain Python stdout into the modem ring buffer.
+    pthread_mutex_lock(&ctx->tx_mutex);
+    ctx->tx_speech_buffer_read_idx = ctx->tx_speech_buffer_write_idx;
+    ctx->tx_eoo_only = true;
+    pthread_cond_signal(&ctx->tx_cond);
+    pthread_mutex_unlock(&ctx->tx_mutex);
+
+    if (kill(ctx->tx_python_pid, SIGUSR1) != 0) {
+        fprintf(stderr, "RADAE TX: SIGUSR1 to python pid %d failed: %s\n",
+                (int)ctx->tx_python_pid, strerror(errno));
+        ctx->tx_eoo_only = false;
+        return false;
+    }
+    if (radae_debug)
+        fprintf(stderr, "RADAE TX: EOO requested (SIGUSR1 -> %d)\n",
+                (int)ctx->tx_python_pid);
+    return true;
 }
 
 bool radae_rx_start(radae_context *ctx)
@@ -305,7 +333,7 @@ void radae_rx_flush(radae_context *ctx)
 
 int radae_tx_write_speech(radae_context *ctx, const float *samples, int n_samples)
 {
-    if (!ctx->tx_running || !samples || n_samples <= 0)
+    if (!ctx->tx_running || ctx->tx_eoo_only || !samples || n_samples <= 0)
         return 0;
     
     pthread_mutex_lock(&ctx->tx_mutex);
@@ -423,13 +451,19 @@ static void *radae_tx_thread(void *arg)
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
              "stdbuf -o0 build/src/lpcnet_demo -features - - | "
-             "python3 -u radae_txe2.py --model_name %s",
+             "python3 -u radae_txe2.py --model_name %s --pid_file %s",
              ctx->radae_dir,
-             RADAE_MODEL_PATH);
-    
+             RADAE_MODEL_PATH,
+             RADAE_TX_PID_FILE);
+
     fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
     if (radae_debug) fprintf(stderr, "RADAE TX: debug enabled\n");
-    
+
+    // Remove any stale pidfile from a prior run so we don't read it and
+    // signal a long-dead Python PID that may have been reassigned.
+    unlink(RADAE_TX_PID_FILE);
+    ctx->tx_python_pid = 0;
+
     // Create pipes for stdin and stdout
     int stdin_pipe[2], stdout_pipe[2];
     if (pipe(stdin_pipe) < 0) {
@@ -556,6 +590,28 @@ static void *radae_tx_thread(void *arg)
         tx_out_csamp_total = 0;
     }
 
+    // Pick up the Python PID that radae_txe2.py wrote to its pidfile.
+    // The subprocess has already produced IQ (or timed out) by this
+    // point, so the pidfile is guaranteed to exist unless Python died
+    // on startup.  We read it once here, not per-EOO, to keep the
+    // signal path fast and avoid racing a just-unlinked file.
+    {
+        FILE *pf = fopen(RADAE_TX_PID_FILE, "r");
+        if (pf) {
+            int p = 0;
+            if (fscanf(pf, "%d", &p) == 1 && p > 1) {
+                ctx->tx_python_pid = (pid_t)p;
+                fprintf(stderr, "RADAE TX: python pid %d (EOO signal target)\n",
+                        (int)ctx->tx_python_pid);
+            }
+            fclose(pf);
+        } else {
+            fprintf(stderr,
+                "RADAE TX: warning: %s missing; EOO on SIGUSR1 disabled "
+                "for this session\n", RADAE_TX_PID_FILE);
+        }
+    }
+
     while (!ctx->shutdown_requested) {
         // Idle branch: PTT is off (or DV mode just got disabled).
         // Don't feed python; don't write to the modem buffer.  Drain
@@ -575,6 +631,9 @@ static void *radae_tx_thread(void *arg)
             pthread_mutex_unlock(&ctx->tx_mutex);
             continue;
         }
+
+        if (ctx->tx_eoo_only)
+            goto read_output;
 
         // Once per iteration, check for stdout starvation.
         if (radae_debug && !tx_starved) {

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -81,8 +81,6 @@ bool radae_is_debug(void) { return radae_debug != 0; }
 
 // TX thread: reads from speech buffer, writes to modem buffer via RADAE pipeline
 static void *radae_tx_thread(void *arg);
-static void *radae_tx_thread_v1(void *arg);
-static void *radae_tx_thread_v2(void *arg);
 
 // RX thread: reads from modem buffer, writes to speech buffer via RADAE pipeline
 static void *radae_rx_thread(void *arg);
@@ -90,11 +88,6 @@ static void *radae_rx_thread(void *arg);
 static bool radae_is_v2(const radae_context *ctx)
 {
     return strcmp(ctx->rade_version, RADAE_VERSION_V1) != 0;
-}
-
-static bool radae_supports_pidfile_eoo(const radae_context *ctx)
-{
-    return radae_is_v2(ctx);
 }
 
 static const char *radae_selected_dir(const radae_context *ctx)
@@ -110,6 +103,16 @@ static const char *radae_selected_tx_binary(const radae_context *ctx)
 static const char *radae_selected_rx_binary(const radae_context *ctx)
 {
     return radae_is_v2(ctx) ? RADAE_RX_BINARY_PATH_V2 : RADAE_RX_BINARY_PATH_V1;
+}
+
+static const char *radae_selected_model_path(const radae_context *ctx)
+{
+    return radae_is_v2(ctx) ? RADAE_MODEL_PATH_V2 : RADAE_MODEL_PATH_V1;
+}
+
+static const char *radae_selected_sync_model_path(const radae_context *ctx)
+{
+    return radae_is_v2(ctx) ? RADAE_SYNC_MODEL_PATH_V2 : RADAE_SYNC_MODEL_PATH_V1;
 }
 
 static void radae_select_version(radae_context *ctx)
@@ -194,10 +197,10 @@ bool radae_init(radae_context *ctx, radio *radio_h)
         fprintf(stderr, "RADAE: debug logging enabled\n");
     }
 
-    // Start the persistent TX thread.  The thread forks the python
-    // pipeline, pre-warms it (torch + numpy imports, model load, first
-    // inference JIT) in the background, then sits idle until PTT.  See
-    // radae_tx_thread for the gating on ctx->tx_running.
+    // Start the persistent TX thread. The thread forks the native
+    // lpcnet_demo -> RADE TX pipeline, pre-warms it in the background,
+    // then sits idle until PTT. See radae_tx_thread for the gating on
+    // ctx->tx_running.
     ctx->tx_running = false;
     if (pthread_create(&ctx->tx_thread, NULL, radae_tx_thread, ctx) != 0) {
         fprintf(stderr, "RADAE: Failed to create TX thread\n");
@@ -238,9 +241,8 @@ void radae_shutdown(radae_context *ctx)
     radae_rx_stop(ctx);
 
     // Tear down the persistent TX pipeline: kill the subprocess, then
-    // join the thread.  The thread's own cleanup path waitpid()s, so
-    // the SIGTERM is a belt-and-suspenders for the case where Python
-    // is stuck (e.g. blocked on read with no EOF yet).
+    // join the thread. The thread's own cleanup path waitpid()s, so the
+    // SIGTERM is belt-and-suspenders for the case where the child is stuck.
     pthread_cond_signal(&ctx->tx_cond);
     if (ctx->tx_encoder_pid > 0) {
         kill(ctx->tx_encoder_pid, SIGTERM);
@@ -261,8 +263,8 @@ void radae_shutdown(radae_context *ctx)
     fprintf(stderr, "RADAE: Shutdown complete\n");
 }
 
-// Flow-control only.  The TX thread and Python subprocess were started
-// at radae_init time and stay alive for the service lifetime; this
+// Flow-control only. The TX thread and encoder subprocess are started at
+// radae_init time and stay alive for the service lifetime; this
 // function just resets the ring buffers and flips the gating flag so
 // radae_tx_write_speech / radae_tx_read_modem_iq begin accepting
 // samples.  The ring-buffer reset is essential — without it, stale IQ
@@ -286,9 +288,8 @@ bool radae_tx_start(radae_context *ctx)
     return true;
 }
 
-// Flow-control only.  Leave the Python subprocess and TX thread alive
-// so the next PTT can start producing IQ within one modem frame
-// instead of re-paying the ~6 s torch/numpy/JIT warmup.  Teardown is
+// Flow-control only. Leave the encoder subprocess and TX thread alive so
+// the next PTT can start producing IQ within one modem frame. Teardown is
 // handled in radae_shutdown.
 void radae_tx_stop(radae_context *ctx)
 {
@@ -316,13 +317,6 @@ bool radae_tx_emit_eoo(radae_context *ctx)
     ctx->tx_eoo_only = true;
     pthread_cond_signal(&ctx->tx_cond);
     pthread_mutex_unlock(&ctx->tx_mutex);
-
-    if (!radae_supports_pidfile_eoo(ctx)) {
-        if (radae_debug)
-            fprintf(stderr, "RADAE TX: EOO requested via stdin close for %s\n",
-                    ctx->rade_version);
-        return true;
-    }
 
     if (ctx->tx_encoder_eoo_pid <= 1) {
         ctx->tx_eoo_only = false;
@@ -508,196 +502,6 @@ static void *radae_tx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
 
-    if (radae_is_v2(ctx))
-        return radae_tx_thread_v2(arg);
-    return radae_tx_thread_v1(arg);
-}
-
-static void *radae_tx_thread_v1(void *arg)
-{
-    radae_context *ctx = (radae_context *)arg;
-    int16_t pcm_buffer[RADAE_FRAME_SIZE];
-    float speech_buffer[RADAE_FRAME_SIZE];
-    float iq_buffer[4096];
-
-    fprintf(stderr, "RADAE TX: using RADEv1 session pipeline\n");
-
-    while (!ctx->shutdown_requested) {
-        if (!ctx->tx_running) {
-            pthread_mutex_lock(&ctx->tx_mutex);
-            struct timespec ts;
-            clock_gettime(CLOCK_REALTIME, &ts);
-            ts.tv_nsec += 50 * 1000 * 1000;
-            if (ts.tv_nsec >= 1000000000) { ts.tv_sec++; ts.tv_nsec -= 1000000000; }
-            pthread_cond_timedwait(&ctx->tx_cond, &ctx->tx_mutex, &ts);
-            pthread_mutex_unlock(&ctx->tx_mutex);
-            continue;
-        }
-
-        char cmd[2048];
-        snprintf(cmd, sizeof(cmd),
-                 "cd %s && "
-                 "stdbuf -o0 build/src/lpcnet_demo -features - - | "
-                 "%s --model_name %s",
-                 ctx->radae_dir,
-                 radae_selected_tx_binary(ctx),
-                 RADAE_MODEL_PATH_V1);
-
-        fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
-
-        int stdin_pipe[2], stdout_pipe[2];
-        if (pipe(stdin_pipe) < 0) {
-            fprintf(stderr, "RADAE TX: Failed to create stdin pipe\n");
-            ctx->tx_running = false;
-            continue;
-        }
-        if (pipe(stdout_pipe) < 0) {
-            fprintf(stderr, "RADAE TX: Failed to create stdout pipe\n");
-            close(stdin_pipe[0]);
-            close(stdin_pipe[1]);
-            ctx->tx_running = false;
-            continue;
-        }
-
-        pid_t pid = fork();
-        if (pid < 0) {
-            fprintf(stderr, "RADAE TX: Fork failed\n");
-            close(stdin_pipe[0]); close(stdin_pipe[1]);
-            close(stdout_pipe[0]); close(stdout_pipe[1]);
-            ctx->tx_running = false;
-            continue;
-        }
-
-        if (pid == 0) {
-            close(stdin_pipe[1]);
-            close(stdout_pipe[0]);
-            dup2(stdin_pipe[0], STDIN_FILENO);
-            dup2(stdout_pipe[1], STDOUT_FILENO);
-            close(stdin_pipe[0]);
-            close(stdout_pipe[1]);
-            execl("/bin/sh", "sh", "-c", cmd, NULL);
-            _exit(1);
-        }
-
-        close(stdin_pipe[0]);
-        close(stdout_pipe[1]);
-
-        ctx->tx_encoder_pid = pid;
-        ctx->tx_encoder_eoo_pid = 0;
-
-        int write_fd = stdin_pipe[1];
-        int read_fd = stdout_pipe[0];
-        int flags = fcntl(read_fd, F_GETFL, 0);
-        fcntl(read_fd, F_SETFL, flags | O_NONBLOCK);
-        bool stdin_closed = false;
-
-        while (!ctx->shutdown_requested) {
-            if (ctx->tx_eoo_only && !stdin_closed) {
-                close(write_fd);
-                write_fd = -1;
-                stdin_closed = true;
-                if (radae_debug)
-                    fprintf(stderr, "RADAE TX: closed V1 stdin to flush EOO\n");
-            }
-
-            if (!ctx->tx_running && !stdin_closed) {
-                close(write_fd);
-                write_fd = -1;
-                stdin_closed = true;
-            }
-
-            if (ctx->tx_running && !ctx->tx_eoo_only) {
-                pthread_mutex_lock(&ctx->tx_mutex);
-                int available = BUFFER_SIZE(ctx->tx_speech_buffer_write_idx,
-                                            ctx->tx_speech_buffer_read_idx,
-                                            RADAE_SPEECH_BUFFER_SIZE);
-
-                if (available >= RADAE_FRAME_SIZE) {
-                    for (int i = 0; i < RADAE_FRAME_SIZE; i++) {
-                        speech_buffer[i] = ctx->tx_speech_buffer[ctx->tx_speech_buffer_read_idx];
-                        ctx->tx_speech_buffer_read_idx = (ctx->tx_speech_buffer_read_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
-                    }
-                    pthread_mutex_unlock(&ctx->tx_mutex);
-
-                    for (int i = 0; i < RADAE_FRAME_SIZE; i++) {
-                        float s = speech_buffer[i] * 32767.0f;
-                        if (s > 32767.0f) s = 32767.0f;
-                        if (s < -32768.0f) s = -32768.0f;
-                        pcm_buffer[i] = (int16_t)s;
-                    }
-
-                    ssize_t written = write(write_fd, pcm_buffer, RADAE_FRAME_SIZE * sizeof(int16_t));
-                    if (written < 0 && errno != EAGAIN) {
-                        fprintf(stderr, "RADAE TX: Write error: %s\n", strerror(errno));
-                        stdin_closed = true;
-                        close(write_fd);
-                        write_fd = -1;
-                    }
-                } else {
-                    struct timespec ts;
-                    clock_gettime(CLOCK_REALTIME, &ts);
-                    ts.tv_nsec += 10 * 1000 * 1000;
-                    if (ts.tv_nsec >= 1000000000) { ts.tv_sec++; ts.tv_nsec -= 1000000000; }
-                    pthread_cond_timedwait(&ctx->tx_cond, &ctx->tx_mutex, &ts);
-                    pthread_mutex_unlock(&ctx->tx_mutex);
-                }
-            }
-
-            ssize_t bytes_read = read(read_fd, iq_buffer, sizeof(iq_buffer));
-            if (bytes_read > 0) {
-                int n_floats = bytes_read / sizeof(float);
-
-                pthread_mutex_lock(&ctx->tx_mutex);
-                int free_space = BUFFER_FREE(ctx->tx_modem_buffer_write_idx,
-                                             ctx->tx_modem_buffer_read_idx,
-                                             RADAE_MODEM_BUFFER_SIZE * 2);
-                int to_write = (n_floats < free_space) ? n_floats : free_space;
-                for (int i = 0; i < to_write; i++) {
-                    ctx->tx_modem_buffer[ctx->tx_modem_buffer_write_idx] = iq_buffer[i];
-                    ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
-                }
-                pthread_mutex_unlock(&ctx->tx_mutex);
-            } else if (bytes_read < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-                fprintf(stderr, "RADAE TX: Read error: %s\n", strerror(errno));
-                break;
-            }
-
-            if (stdin_closed) {
-                int status = 0;
-                pid_t done = waitpid(pid, &status, WNOHANG);
-                if (done == pid)
-                    break;
-            }
-        }
-
-        if (write_fd >= 0)
-            close(write_fd);
-        close(read_fd);
-        waitpid(pid, NULL, 0);
-        ctx->tx_encoder_pid = 0;
-        ctx->tx_encoder_eoo_pid = 0;
-        ctx->tx_running = false;
-        ctx->tx_eoo_only = false;
-    }
-
-    fprintf(stderr, "RADAE TX: Thread exiting\n");
-    return NULL;
-}
-
-static void *radae_tx_thread_v2(void *arg)
-{
-    radae_context *ctx = (radae_context *)arg;
-
-    // Build command for TX pipeline
-    // RADEv2: lpcnet_demo -features -> native radae_tx_v2 -> IQ samples
-
-    // stdbuf -o0 forces lpcnet_demo's stdout to be unbuffered.  When glibc
-    // detects a non-TTY (i.e. a pipe), it defaults stdout to full block
-    // buffering (~64 KiB).  At ~14.4 KiB/s of feature data that means ~4.5 s
-    // of silence from the encoder script after PTT — historical "py stdout
-    // STARVED 6.35s" symptom seen when this stage was Python.  The native
-    // binary writes per-frame so this is belt-and-suspenders, but stdbuf
-    // remains correct.
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
@@ -705,14 +509,14 @@ static void *radae_tx_thread_v2(void *arg)
              "%s --model_name %s --pid_file %s",
              ctx->radae_dir,
              radae_selected_tx_binary(ctx),
-             RADAE_MODEL_PATH_V2,
+             radae_selected_model_path(ctx),
              RADAE_TX_PID_FILE);
 
     fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
     if (radae_debug) fprintf(stderr, "RADAE TX: debug enabled\n");
 
     // Remove any stale pidfile from a prior run so we don't read it and
-    // signal a long-dead Python PID that may have been reassigned.
+    // signal a long-dead encoder PID that may have been reassigned.
     unlink(RADAE_TX_PID_FILE);
     ctx->tx_encoder_eoo_pid = 0;
 
@@ -775,13 +579,13 @@ static void *radae_tx_thread_v2(void *arg)
     // Buffer for reading IQ from pipe
     float iq_buffer[4096];
 
-    // Starvation detector for the Python pipeline's stdout.
+    // Starvation detector for the encoder pipeline's stdout.
     // We report once when stdout has been silent for >STARVE_THRESH_S
     // and once again when it resumes.  Cumulative totals make the ratio
     // between input (speech) and output (IQ) visible at a glance.
-    // With the persistent-pipeline refactor, the only STARVED event we
-    // expect to see is during the init-time warmup below — every PTT
-    // thereafter should produce IQ within one modem frame.
+    // The only STARVED event we expect to see is during the init-time
+    // warmup below — every PTT thereafter should produce IQ within one
+    // modem frame.
     const double STARVE_THRESH_S = 0.5;
     struct timespec tx_start_t;
     clock_gettime(CLOCK_MONOTONIC, &tx_start_t);
@@ -790,14 +594,10 @@ static void *radae_tx_thread_v2(void *arg)
     uint64_t tx_in_samp_total   = 0;
     uint64_t tx_out_csamp_total = 0;
 
-    // Pre-warm: amortize the ~6 s torch + numpy import + model load +
-    // first-inference JIT cost *before* the first PTT.  Feed 1 s of
-    // zero-valued 16 kHz PCM, read and discard the resulting IQ, then
-    // drop through to the main loop where tx_running gates everything.
-    // Writes are blocking and Python only reads ~16 kB/s while the
-    // first inference is still compiling, so the pipe buffer
-    // back-pressures us — that's fine, we run in the background while
-    // the rest of sbitx finishes initializing.
+    // Pre-warm the feature extractor + encoder path before first PTT.
+    // Feed 1 s of zero-valued 16 kHz PCM, read and discard the resulting
+    // IQ, then drop through to the main loop where tx_running gates
+    // everything.
     {
         fprintf(stderr, "RADAE TX: pre-warming TX pipeline...\n");
         int16_t warm_pcm[RADAE_FRAME_SIZE];
@@ -809,11 +609,10 @@ static void *radae_tx_thread_v2(void *arg)
             ssize_t w = write(write_fd, warm_pcm, sizeof(warm_pcm));
             (void)w;
             // Drain whatever IQ has come out so far to keep the
-            // stdout pipe empty and avoid back-pressuring Python.
+            // stdout pipe empty and avoid back-pressure.
             while (read(read_fd, iq_buffer, sizeof(iq_buffer)) > 0) {}
         }
-        // Wait up to 15 s for the first output frame — this is the
-        // signal that JIT is complete.
+        // Wait up to 15 s for the first output frame.
         bool warm_ok = false;
         struct timespec t_deadline = warm_t0;
         t_deadline.tv_sec += 15;
@@ -842,9 +641,9 @@ static void *radae_tx_thread_v2(void *arg)
         tx_out_csamp_total = 0;
     }
 
-    // Pick up the native TX PID that radae_tx_v2 wrote to its pidfile.
-    // The subprocess has already produced IQ (or timed out) by this
-    // point, so the pidfile is guaranteed to exist unless Python died
+    // Pick up the native TX PID that radae_tx wrote to its pidfile. The
+    // subprocess has already produced IQ (or timed out) by this point,
+    // so the pidfile is guaranteed to exist unless the encoder died
     // on startup.  We read it once here, not per-EOO, to keep the
     // signal path fast and avoid racing a just-unlinked file.
     {
@@ -866,7 +665,7 @@ static void *radae_tx_thread_v2(void *arg)
 
     while (!ctx->shutdown_requested) {
         // Idle branch: PTT is off (or DV mode just got disabled).
-        // Don't feed python; don't write to the modem buffer.  Drain
+        // Don't feed the encoder; don't write to the modem buffer. Drain
         // any stale IQ so it doesn't leak into the next key-down, and
         // keep tx_out_last_t fresh so the starvation detector doesn't
         // fire spuriously while we wait.
@@ -895,7 +694,7 @@ static void *radae_tx_thread_v2(void *arg)
                              (_now.tv_nsec - tx_out_last_t.tv_nsec) / 1e9;
             if (silence > STARVE_THRESH_S) {
                 fprintf(stderr,
-                    "RADAE TX: py stdout STARVED %.2fs silent "
+                    "RADAE TX: encoder stdout STARVED %.2fs silent "
                     "(in=%llu samp, out=%llu csamp, ratio out/in=%.4f)\n",
                     silence,
                     (unsigned long long)tx_in_samp_total,
@@ -951,7 +750,7 @@ static void *radae_tx_thread_v2(void *arg)
         }
         if (written > 0) {
             tx_in_samp_total += (uint64_t)(written / sizeof(int16_t));
-            RADAE_RATE_LOG("tx_py_stdin  ctx->py",  "samp",
+            RADAE_RATE_LOG("tx_enc_stdin ctx->enc", "samp",
                            (int)(written / sizeof(int16_t)), "16000 samp/s");
         }
 
@@ -982,7 +781,7 @@ static void *radae_tx_thread_v2(void *arg)
                 double silence = (_now.tv_sec  - tx_out_last_t.tv_sec) +
                                  (_now.tv_nsec - tx_out_last_t.tv_nsec) / 1e9;
                 fprintf(stderr,
-                    "RADAE TX: py stdout RESUMED after %.2fs "
+                    "RADAE TX: encoder stdout RESUMED after %.2fs "
                     "(in=%llu samp, out=%llu csamp, ratio out/in=%.4f)\n",
                     silence,
                     (unsigned long long)tx_in_samp_total,
@@ -994,7 +793,7 @@ static void *radae_tx_thread_v2(void *arg)
             tx_out_last_t = _now;
 
             // n_floats is interleaved I/Q, so csamp count = n_floats/2
-            RADAE_RATE_LOG("tx_py_stdout py->ctx",  "csamp",
+            RADAE_RATE_LOG("tx_enc_stdout enc->ctx", "csamp",
                            n_floats / 2, "8000 csamp/s");
         }
     }
@@ -1005,6 +804,7 @@ static void *radae_tx_thread_v2(void *arg)
     // Wait for child process
     waitpid(pid, NULL, 0);
     ctx->tx_encoder_pid = 0;
+    ctx->tx_encoder_eoo_pid = 0;
 
     if (radae_debug) {
         struct timespec _now;
@@ -1034,31 +834,17 @@ static void *radae_rx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
     
-    char verbose_arg[16] = "";
+    const char *verbose_arg = radae_is_debug() ? "--verbose" : "--quiet";
     char cmd[2048];
-    if (radae_is_v2(ctx)) {
-        if (radae_is_debug())
-            strcpy(verbose_arg, " -v");
-        snprintf(cmd, sizeof(cmd),
-                 "cd %s && "
-                 "%s --model_name %s --frame_sync_model_name %s%s | "
-                 "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
-                 ctx->radae_dir,
-                 radae_selected_rx_binary(ctx),
-                 RADAE_MODEL_PATH_V2,
-                 RADAE_SYNC_MODEL_PATH_V2,
-                 verbose_arg);
-    } else {
-        strcpy(verbose_arg, radae_is_debug() ? " -v 1" : " -v 0");
-        snprintf(cmd, sizeof(cmd),
-                 "cd %s && "
-                 "%s --model_name %s%s | "
-                 "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
-                 ctx->radae_dir,
-                 radae_selected_rx_binary(ctx),
-                 RADAE_MODEL_PATH_V1,
-                 verbose_arg);
-    }
+    snprintf(cmd, sizeof(cmd),
+             "cd %s && "
+             "%s --model_name %s --frame_sync_model_name %s %s | "
+             "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
+             ctx->radae_dir,
+             radae_selected_rx_binary(ctx),
+             radae_selected_model_path(ctx),
+             radae_selected_sync_model_path(ctx),
+             verbose_arg);
     
     fprintf(stderr, "RADAE RX: Starting pipeline: %s\n", cmd);
     if (radae_debug) fprintf(stderr, "RADAE RX: debug enabled\n");
@@ -1156,7 +942,7 @@ static void *radae_rx_thread(void *arg)
         }
         if (written > 0) {
             // iq_buffer is interleaved I/Q floats, so csamp count = floats/2
-            RADAE_RATE_LOG("rx_py_stdin  ctx->py",  "csamp",
+            RADAE_RATE_LOG("rx_dec_stdin ctx->dec", "csamp",
                            (int)(written / sizeof(float)) / 2, "8000 csamp/s");
         }
 
@@ -1177,7 +963,7 @@ static void *radae_rx_thread(void *arg)
                 ctx->rx_speech_buffer_write_idx = (ctx->rx_speech_buffer_write_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
             }
             pthread_mutex_unlock(&ctx->rx_mutex);
-            RADAE_RATE_LOG("rx_py_stdout py->ctx", "samp",
+            RADAE_RATE_LOG("rx_dec_stdout dec->ctx", "samp",
                            n_samples, "16000 samp/s (when synced)");
         }
     }

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -538,9 +538,10 @@ static void *radae_tx_thread_v1(void *arg)
         snprintf(cmd, sizeof(cmd),
                  "cd %s && "
                  "stdbuf -o0 build/src/lpcnet_demo -features - - | "
-                 "%s",
+                 "%s --model_name %s",
                  ctx->radae_dir,
-                 radae_selected_tx_binary(ctx));
+                 radae_selected_tx_binary(ctx),
+                 RADAE_MODEL_PATH_V1);
 
         fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
 
@@ -1033,7 +1034,7 @@ static void *radae_rx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
     
-    char verbose_arg[8] = "";
+    char verbose_arg[16] = "";
     char cmd[2048];
     if (radae_is_v2(ctx)) {
         if (radae_is_debug())
@@ -1048,14 +1049,14 @@ static void *radae_rx_thread(void *arg)
                  RADAE_SYNC_MODEL_PATH_V2,
                  verbose_arg);
     } else {
-        if (radae_is_debug())
-            strcpy(verbose_arg, " -v 1");
+        strcpy(verbose_arg, radae_is_debug() ? " -v 1" : " -v 0");
         snprintf(cmd, sizeof(cmd),
                  "cd %s && "
-                 "%s%s | "
+                 "%s --model_name %s%s | "
                  "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
                  ctx->radae_dir,
                  radae_selected_rx_binary(ctx),
+                 RADAE_MODEL_PATH_V1,
                  verbose_arg);
     }
     

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -777,25 +777,26 @@ static void *radae_tx_thread(void *arg)
 }
 
 // RX thread implementation
-// Pipeline: modem IQ (8kHz) -> radae_rxe2.py -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
+// Pipeline: modem IQ (8kHz) -> radae_rx_v2 -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
 static void *radae_rx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
     
-    // RADEv2 RX pipeline: IQ samples -> radae_rxe2.py -> features -> lpcnet_demo -fargan-synthesis
+    // RADEv2 RX pipeline: IQ samples -> native radae_rx_v2 -> features -> lpcnet_demo -fargan-synthesis
 
     // Same stdio-buffering workaround as TX: lpcnet_demo's stdout is fully
     // buffered when piped, delaying audio arrival by up to the buffer size.
-    // -u on Python is defensive; radae_rxe2.py already flushes per write.
+    // The native decoder binary flushes per emitted feature block.
     char verbose_arg[8] = "";
     char cmd[2048];
     if (radae_is_debug())
         strcpy(verbose_arg, " -v");
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
-             "python3 -u radae_rxe2.py --model_name %s --frame_sync_model_name %s%s | "
+             "%s --model_name %s --frame_sync_model_name %s%s | "
              "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
              ctx->radae_dir,
+             RADAE_RX_BINARY_PATH,
              RADAE_MODEL_PATH,
              RADAE_SYNC_MODEL_PATH,
              verbose_arg);

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -287,6 +287,22 @@ void radae_rx_stop(radae_context *ctx)
     fprintf(stderr, "RADAE RX: Stopped\n");
 }
 
+void radae_rx_flush(radae_context *ctx)
+{
+    if (!ctx)
+        return;
+    
+    pthread_mutex_lock(&ctx->rx_mutex);
+    
+    // Reset buffer indices to discard any stale IQ/speech data
+    ctx->rx_modem_buffer_write_idx = 0;
+    ctx->rx_modem_buffer_read_idx = 0;
+    ctx->rx_speech_buffer_write_idx = 0;
+    ctx->rx_speech_buffer_read_idx = 0;
+    
+    pthread_mutex_unlock(&ctx->rx_mutex);
+}
+
 int radae_tx_write_speech(radae_context *ctx, const float *samples, int n_samples)
 {
     if (!ctx->tx_running || !samples || n_samples <= 0)

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -432,27 +432,28 @@ int radae_rx_read_speech(radae_context *ctx, float *samples, int max_samples)
 }
 
 // TX thread implementation
-// Pipeline: speech (16kHz) -> lpcnet_demo -features -> radae_txe2.py -> modem IQ (8kHz)
+// Pipeline: speech (16kHz) -> lpcnet_demo -features -> radae_tx_v2 -> modem IQ (8kHz)
 static void *radae_tx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
-    
+
     // Build command for TX pipeline
-    // RADEv2: lpcnet_demo -features -> radae_txe2.py -> IQ samples
+    // RADEv2: lpcnet_demo -features -> native radae_tx_v2 -> IQ samples
 
     // stdbuf -o0 forces lpcnet_demo's stdout to be unbuffered.  When glibc
     // detects a non-TTY (i.e. a pipe), it defaults stdout to full block
     // buffering (~64 KiB).  At ~14.4 KiB/s of feature data that means ~4.5 s
-    // of silence from the Python script after PTT — observed as "py stdout
-    // STARVED 6.35s" with out/in=0.0032 after a 10 s key-down.
-    // python3 -u is defensive; the script already calls stdout.flush() each
-    // frame but -u guarantees unbuffered I/O in all future code paths.
+    // of silence from the encoder script after PTT — historical "py stdout
+    // STARVED 6.35s" symptom seen when this stage was Python.  The native
+    // binary writes per-frame so this is belt-and-suspenders, but stdbuf
+    // remains correct.
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
              "cd %s && "
              "stdbuf -o0 build/src/lpcnet_demo -features - - | "
-             "python3 -u radae_txe2.py --model_name %s --pid_file %s",
+             "%s --model_name %s --pid_file %s",
              ctx->radae_dir,
+             RADAE_TX_BINARY_PATH,
              RADAE_MODEL_PATH,
              RADAE_TX_PID_FILE);
 

--- a/trx_v2-userland/sbitx_radae.c
+++ b/trx_v2-userland/sbitx_radae.c
@@ -1,5 +1,5 @@
 /*
- * sBitx RADEv2 Digital Voice Integration
+ * sBitx RADE digital voice integration
  *
  * Copyright (C) 2024-2025 Rhizomatica
  * Author: Rafael Diniz <rafael@rhizomatica.org>
@@ -19,8 +19,7 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  *
- * RADEv2 - Radio Autoencoder Version 2
- * Uses subprocess pipelines with Python scripts for encoding/decoding.
+ * Supports side-by-side RADEv1 (radae_nopy) and RADEv2 native C pipelines.
  */
 
 #include <stdio.h>
@@ -82,16 +81,73 @@ bool radae_is_debug(void) { return radae_debug != 0; }
 
 // TX thread: reads from speech buffer, writes to modem buffer via RADAE pipeline
 static void *radae_tx_thread(void *arg);
+static void *radae_tx_thread_v1(void *arg);
+static void *radae_tx_thread_v2(void *arg);
 
 // RX thread: reads from modem buffer, writes to speech buffer via RADAE pipeline
 static void *radae_rx_thread(void *arg);
 
-bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir)
+static bool radae_is_v2(const radae_context *ctx)
+{
+    return strcmp(ctx->rade_version, RADAE_VERSION_V1) != 0;
+}
+
+static bool radae_supports_pidfile_eoo(const radae_context *ctx)
+{
+    return radae_is_v2(ctx);
+}
+
+static const char *radae_selected_dir(const radae_context *ctx)
+{
+    return radae_is_v2(ctx) ? RADAE_DIR_V2 : RADAE_DIR_V1;
+}
+
+static const char *radae_selected_tx_binary(const radae_context *ctx)
+{
+    return radae_is_v2(ctx) ? RADAE_TX_BINARY_PATH_V2 : RADAE_TX_BINARY_PATH_V1;
+}
+
+static const char *radae_selected_rx_binary(const radae_context *ctx)
+{
+    return radae_is_v2(ctx) ? RADAE_RX_BINARY_PATH_V2 : RADAE_RX_BINARY_PATH_V1;
+}
+
+static void radae_select_version(radae_context *ctx)
+{
+    const char *selected = RADAE_VERSION_DEFAULT;
+    int invalid = 0;
+
+    if (ctx->radio_h != NULL && ctx->radio_h->cfg_user != NULL) {
+        pthread_mutex_lock(&ctx->radio_h->cfg_mutex);
+        const char *configured = iniparser_getstring(ctx->radio_h->cfg_user,
+                                                     "main:rade_version",
+                                                     RADAE_VERSION_DEFAULT);
+        if (configured != NULL && strcmp(configured, RADAE_VERSION_V1) == 0) {
+            selected = RADAE_VERSION_V1;
+        } else if (configured != NULL && strcmp(configured, RADAE_VERSION_V2) == 0) {
+            selected = RADAE_VERSION_V2;
+        } else if (configured != NULL) {
+            invalid = 1;
+        }
+        pthread_mutex_unlock(&ctx->radio_h->cfg_mutex);
+    }
+
+    strncpy(ctx->rade_version, selected, sizeof(ctx->rade_version) - 1);
+    strncpy(ctx->radae_dir, radae_selected_dir(ctx), sizeof(ctx->radae_dir) - 1);
+
+    if (invalid) {
+        fprintf(stderr,
+                "RADAE: invalid main:rade_version in user.ini, defaulting to %s\n",
+                RADAE_VERSION_DEFAULT);
+    }
+}
+
+bool radae_init(radae_context *ctx, radio *radio_h)
 {
     memset(ctx, 0, sizeof(radae_context));
     
     ctx->radio_h = radio_h;
-    strncpy(ctx->radae_dir, radae_dir, sizeof(ctx->radae_dir) - 1);
+    radae_select_version(ctx);
     
     // Initialize mutexes and condition variables
     pthread_mutex_init(&ctx->tx_mutex, NULL);
@@ -148,7 +204,8 @@ bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir)
         goto cleanup_rx_speech;
     }
 
-    fprintf(stderr, "RADAE: Initialized with radae_dir=%s\n", ctx->radae_dir);
+    fprintf(stderr, "RADAE: Initialized version=%s radae_dir=%s\n",
+            ctx->rade_version, ctx->radae_dir);
 
     return true;
 
@@ -235,28 +292,42 @@ bool radae_tx_start(radae_context *ctx)
 // handled in radae_shutdown.
 void radae_tx_stop(radae_context *ctx)
 {
-    if (!ctx->tx_running)
+    if (!ctx->tx_running && !ctx->tx_eoo_only)
         return;
 
-    ctx->tx_eoo_only = false;
+    pthread_mutex_lock(&ctx->tx_mutex);
+    ctx->tx_speech_buffer_read_idx = ctx->tx_speech_buffer_write_idx;
     ctx->tx_running = false;
     pthread_cond_signal(&ctx->tx_cond);
+    pthread_mutex_unlock(&ctx->tx_mutex);
     fprintf(stderr, "RADAE TX: flow disabled\n");
 }
 
 bool radae_tx_emit_eoo(radae_context *ctx)
 {
-    if (!ctx || !ctx->initialized || ctx->tx_encoder_eoo_pid <= 1)
+    if (!ctx || !ctx->initialized || ctx->tx_encoder_pid <= 1)
         return false;
 
     // Prevent any queued speech/silence after PTT-off from being encoded
     // after the EOO frame. From this point until tr_switch finishes, the
-    // TX thread should only drain Python stdout into the modem ring buffer.
+    // TX thread should only drain encoder stdout into the modem ring buffer.
     pthread_mutex_lock(&ctx->tx_mutex);
     ctx->tx_speech_buffer_read_idx = ctx->tx_speech_buffer_write_idx;
     ctx->tx_eoo_only = true;
     pthread_cond_signal(&ctx->tx_cond);
     pthread_mutex_unlock(&ctx->tx_mutex);
+
+    if (!radae_supports_pidfile_eoo(ctx)) {
+        if (radae_debug)
+            fprintf(stderr, "RADAE TX: EOO requested via stdin close for %s\n",
+                    ctx->rade_version);
+        return true;
+    }
+
+    if (ctx->tx_encoder_eoo_pid <= 1) {
+        ctx->tx_eoo_only = false;
+        return false;
+    }
 
     if (kill(ctx->tx_encoder_eoo_pid, SIGUSR1) != 0) {
         fprintf(stderr, "RADAE TX: SIGUSR1 to encoder pid %d failed: %s\n",
@@ -432,8 +503,187 @@ int radae_rx_read_speech(radae_context *ctx, float *samples, int max_samples)
 }
 
 // TX thread implementation
-// Pipeline: speech (16kHz) -> lpcnet_demo -features -> radae_tx_v2 -> modem IQ (8kHz)
+// Pipeline: speech (16kHz) -> lpcnet_demo -features -> RADE TX -> modem IQ (8kHz)
 static void *radae_tx_thread(void *arg)
+{
+    radae_context *ctx = (radae_context *)arg;
+
+    if (radae_is_v2(ctx))
+        return radae_tx_thread_v2(arg);
+    return radae_tx_thread_v1(arg);
+}
+
+static void *radae_tx_thread_v1(void *arg)
+{
+    radae_context *ctx = (radae_context *)arg;
+    int16_t pcm_buffer[RADAE_FRAME_SIZE];
+    float speech_buffer[RADAE_FRAME_SIZE];
+    float iq_buffer[4096];
+
+    fprintf(stderr, "RADAE TX: using RADEv1 session pipeline\n");
+
+    while (!ctx->shutdown_requested) {
+        if (!ctx->tx_running) {
+            pthread_mutex_lock(&ctx->tx_mutex);
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_nsec += 50 * 1000 * 1000;
+            if (ts.tv_nsec >= 1000000000) { ts.tv_sec++; ts.tv_nsec -= 1000000000; }
+            pthread_cond_timedwait(&ctx->tx_cond, &ctx->tx_mutex, &ts);
+            pthread_mutex_unlock(&ctx->tx_mutex);
+            continue;
+        }
+
+        char cmd[2048];
+        snprintf(cmd, sizeof(cmd),
+                 "cd %s && "
+                 "stdbuf -o0 build/src/lpcnet_demo -features - - | "
+                 "%s",
+                 ctx->radae_dir,
+                 radae_selected_tx_binary(ctx));
+
+        fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
+
+        int stdin_pipe[2], stdout_pipe[2];
+        if (pipe(stdin_pipe) < 0) {
+            fprintf(stderr, "RADAE TX: Failed to create stdin pipe\n");
+            ctx->tx_running = false;
+            continue;
+        }
+        if (pipe(stdout_pipe) < 0) {
+            fprintf(stderr, "RADAE TX: Failed to create stdout pipe\n");
+            close(stdin_pipe[0]);
+            close(stdin_pipe[1]);
+            ctx->tx_running = false;
+            continue;
+        }
+
+        pid_t pid = fork();
+        if (pid < 0) {
+            fprintf(stderr, "RADAE TX: Fork failed\n");
+            close(stdin_pipe[0]); close(stdin_pipe[1]);
+            close(stdout_pipe[0]); close(stdout_pipe[1]);
+            ctx->tx_running = false;
+            continue;
+        }
+
+        if (pid == 0) {
+            close(stdin_pipe[1]);
+            close(stdout_pipe[0]);
+            dup2(stdin_pipe[0], STDIN_FILENO);
+            dup2(stdout_pipe[1], STDOUT_FILENO);
+            close(stdin_pipe[0]);
+            close(stdout_pipe[1]);
+            execl("/bin/sh", "sh", "-c", cmd, NULL);
+            _exit(1);
+        }
+
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+
+        ctx->tx_encoder_pid = pid;
+        ctx->tx_encoder_eoo_pid = 0;
+
+        int write_fd = stdin_pipe[1];
+        int read_fd = stdout_pipe[0];
+        int flags = fcntl(read_fd, F_GETFL, 0);
+        fcntl(read_fd, F_SETFL, flags | O_NONBLOCK);
+        bool stdin_closed = false;
+
+        while (!ctx->shutdown_requested) {
+            if (ctx->tx_eoo_only && !stdin_closed) {
+                close(write_fd);
+                write_fd = -1;
+                stdin_closed = true;
+                if (radae_debug)
+                    fprintf(stderr, "RADAE TX: closed V1 stdin to flush EOO\n");
+            }
+
+            if (!ctx->tx_running && !stdin_closed) {
+                close(write_fd);
+                write_fd = -1;
+                stdin_closed = true;
+            }
+
+            if (ctx->tx_running && !ctx->tx_eoo_only) {
+                pthread_mutex_lock(&ctx->tx_mutex);
+                int available = BUFFER_SIZE(ctx->tx_speech_buffer_write_idx,
+                                            ctx->tx_speech_buffer_read_idx,
+                                            RADAE_SPEECH_BUFFER_SIZE);
+
+                if (available >= RADAE_FRAME_SIZE) {
+                    for (int i = 0; i < RADAE_FRAME_SIZE; i++) {
+                        speech_buffer[i] = ctx->tx_speech_buffer[ctx->tx_speech_buffer_read_idx];
+                        ctx->tx_speech_buffer_read_idx = (ctx->tx_speech_buffer_read_idx + 1) % RADAE_SPEECH_BUFFER_SIZE;
+                    }
+                    pthread_mutex_unlock(&ctx->tx_mutex);
+
+                    for (int i = 0; i < RADAE_FRAME_SIZE; i++) {
+                        float s = speech_buffer[i] * 32767.0f;
+                        if (s > 32767.0f) s = 32767.0f;
+                        if (s < -32768.0f) s = -32768.0f;
+                        pcm_buffer[i] = (int16_t)s;
+                    }
+
+                    ssize_t written = write(write_fd, pcm_buffer, RADAE_FRAME_SIZE * sizeof(int16_t));
+                    if (written < 0 && errno != EAGAIN) {
+                        fprintf(stderr, "RADAE TX: Write error: %s\n", strerror(errno));
+                        stdin_closed = true;
+                        close(write_fd);
+                        write_fd = -1;
+                    }
+                } else {
+                    struct timespec ts;
+                    clock_gettime(CLOCK_REALTIME, &ts);
+                    ts.tv_nsec += 10 * 1000 * 1000;
+                    if (ts.tv_nsec >= 1000000000) { ts.tv_sec++; ts.tv_nsec -= 1000000000; }
+                    pthread_cond_timedwait(&ctx->tx_cond, &ctx->tx_mutex, &ts);
+                    pthread_mutex_unlock(&ctx->tx_mutex);
+                }
+            }
+
+            ssize_t bytes_read = read(read_fd, iq_buffer, sizeof(iq_buffer));
+            if (bytes_read > 0) {
+                int n_floats = bytes_read / sizeof(float);
+
+                pthread_mutex_lock(&ctx->tx_mutex);
+                int free_space = BUFFER_FREE(ctx->tx_modem_buffer_write_idx,
+                                             ctx->tx_modem_buffer_read_idx,
+                                             RADAE_MODEM_BUFFER_SIZE * 2);
+                int to_write = (n_floats < free_space) ? n_floats : free_space;
+                for (int i = 0; i < to_write; i++) {
+                    ctx->tx_modem_buffer[ctx->tx_modem_buffer_write_idx] = iq_buffer[i];
+                    ctx->tx_modem_buffer_write_idx = (ctx->tx_modem_buffer_write_idx + 1) % (RADAE_MODEM_BUFFER_SIZE * 2);
+                }
+                pthread_mutex_unlock(&ctx->tx_mutex);
+            } else if (bytes_read < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+                fprintf(stderr, "RADAE TX: Read error: %s\n", strerror(errno));
+                break;
+            }
+
+            if (stdin_closed) {
+                int status = 0;
+                pid_t done = waitpid(pid, &status, WNOHANG);
+                if (done == pid)
+                    break;
+            }
+        }
+
+        if (write_fd >= 0)
+            close(write_fd);
+        close(read_fd);
+        waitpid(pid, NULL, 0);
+        ctx->tx_encoder_pid = 0;
+        ctx->tx_encoder_eoo_pid = 0;
+        ctx->tx_running = false;
+        ctx->tx_eoo_only = false;
+    }
+
+    fprintf(stderr, "RADAE TX: Thread exiting\n");
+    return NULL;
+}
+
+static void *radae_tx_thread_v2(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
 
@@ -453,8 +703,8 @@ static void *radae_tx_thread(void *arg)
              "stdbuf -o0 build/src/lpcnet_demo -features - - | "
              "%s --model_name %s --pid_file %s",
              ctx->radae_dir,
-             RADAE_TX_BINARY_PATH,
-             RADAE_MODEL_PATH,
+             radae_selected_tx_binary(ctx),
+             RADAE_MODEL_PATH_V2,
              RADAE_TX_PID_FILE);
 
     fprintf(stderr, "RADAE TX: Starting pipeline: %s\n", cmd);
@@ -591,7 +841,7 @@ static void *radae_tx_thread(void *arg)
         tx_out_csamp_total = 0;
     }
 
-    // Pick up the Python PID that radae_txe2.py wrote to its pidfile.
+    // Pick up the native TX PID that radae_tx_v2 wrote to its pidfile.
     // The subprocess has already produced IQ (or timed out) by this
     // point, so the pidfile is guaranteed to exist unless Python died
     // on startup.  We read it once here, not per-EOO, to keep the
@@ -778,29 +1028,36 @@ static void *radae_tx_thread(void *arg)
 }
 
 // RX thread implementation
-// Pipeline: modem IQ (8kHz) -> radae_rx_v2 -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
+// Pipeline: modem IQ (8kHz) -> RADE RX -> lpcnet_demo -fargan-synthesis -> speech (16kHz)
 static void *radae_rx_thread(void *arg)
 {
     radae_context *ctx = (radae_context *)arg;
     
-    // RADEv2 RX pipeline: IQ samples -> native radae_rx_v2 -> features -> lpcnet_demo -fargan-synthesis
-
-    // Same stdio-buffering workaround as TX: lpcnet_demo's stdout is fully
-    // buffered when piped, delaying audio arrival by up to the buffer size.
-    // The native decoder binary flushes per emitted feature block.
     char verbose_arg[8] = "";
     char cmd[2048];
-    if (radae_is_debug())
-        strcpy(verbose_arg, " -v");
-    snprintf(cmd, sizeof(cmd),
-             "cd %s && "
-             "%s --model_name %s --frame_sync_model_name %s%s | "
-             "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
-             ctx->radae_dir,
-             RADAE_RX_BINARY_PATH,
-             RADAE_MODEL_PATH,
-             RADAE_SYNC_MODEL_PATH,
-             verbose_arg);
+    if (radae_is_v2(ctx)) {
+        if (radae_is_debug())
+            strcpy(verbose_arg, " -v");
+        snprintf(cmd, sizeof(cmd),
+                 "cd %s && "
+                 "%s --model_name %s --frame_sync_model_name %s%s | "
+                 "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
+                 ctx->radae_dir,
+                 radae_selected_rx_binary(ctx),
+                 RADAE_MODEL_PATH_V2,
+                 RADAE_SYNC_MODEL_PATH_V2,
+                 verbose_arg);
+    } else {
+        if (radae_is_debug())
+            strcpy(verbose_arg, " -v 1");
+        snprintf(cmd, sizeof(cmd),
+                 "cd %s && "
+                 "%s%s | "
+                 "stdbuf -o0 build/src/lpcnet_demo -fargan-synthesis - -",
+                 ctx->radae_dir,
+                 radae_selected_rx_binary(ctx),
+                 verbose_arg);
+    }
     
     fprintf(stderr, "RADAE RX: Starting pipeline: %s\n", cmd);
     if (radae_debug) fprintf(stderr, "RADAE RX: debug enabled\n");

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -1,0 +1,140 @@
+/*
+ * sBitx RADEv2 Digital Voice Integration
+ *
+ * Copyright (C) 2024-2025 Rhizomatica
+ * Author: Rafael Diniz <rafael@rhizomatica.org>
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ *
+ * RADEv2 - Radio Autoencoder Version 2
+ * See: https://github.com/drowe67/radae
+ */
+
+#ifndef SBITX_RADAE_H_
+#define SBITX_RADAE_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include "sbitx_core.h"
+
+// Sample rates
+#define RADAE_MODEM_RATE     8000   // RADAE modem IQ sample rate
+#define RADAE_SPEECH_RATE    16000  // RADAE speech sample rate (for lpcnet)
+
+
+// Buffer sizes
+#define RADAE_SPEECH_BUFFER_SIZE   (RADAE_SPEECH_RATE * 2)  // 2 seconds of speech
+#define RADAE_MODEM_BUFFER_SIZE    (RADAE_MODEM_RATE * 2)   // 2 seconds of modem IQ
+
+// Feature extraction frame size (10ms @ 16kHz = 160 samples)
+#define RADAE_FRAME_SIZE     160
+
+// Paths to RADAE resources (relative to radae directory)
+#define RADAE_MODEL_PATH         "250725/checkpoints/checkpoint_epoch_200.pth"
+#define RADAE_DIR                "../radae"
+
+// RADAE context structure
+typedef struct {
+    // Subprocess PIDs
+    pid_t tx_encoder_pid;    // TX encoder pipeline
+    pid_t rx_decoder_pid;    // RX decoder pipeline
+
+    // Circular buffers for sample rate conversion
+    float *tx_speech_buffer;         // 16kHz speech input buffer
+    int tx_speech_buffer_write_idx;
+    int tx_speech_buffer_read_idx;
+
+    float *tx_modem_buffer;          // 8kHz complex IQ output buffer
+    int tx_modem_buffer_write_idx;
+    int tx_modem_buffer_read_idx;
+
+    float *rx_modem_buffer;          // 8kHz complex IQ input buffer
+    int rx_modem_buffer_write_idx;
+    int rx_modem_buffer_read_idx;
+
+    float *rx_speech_buffer;         // 16kHz speech output buffer
+    int rx_speech_buffer_write_idx;
+    int rx_speech_buffer_read_idx;
+
+    // Thread handles
+    pthread_t tx_thread;
+    pthread_t rx_thread;
+
+    // Mutex for buffer access
+    pthread_mutex_t tx_mutex;
+    pthread_mutex_t rx_mutex;
+
+    // Condition variables for signaling
+    pthread_cond_t tx_cond;
+    pthread_cond_t rx_cond;
+
+    // State flags
+    _Atomic bool initialized;
+    _Atomic bool tx_running;
+    _Atomic bool rx_running;
+    _Atomic bool shutdown_requested;
+
+    // Radio handle reference
+    radio *radio_h;
+
+    // RADAE directory path
+    char radae_dir[256];
+
+} radae_context;
+
+// Initialize RADAE subsystem
+bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir);
+
+// Shutdown RADAE subsystem
+void radae_shutdown(radae_context *ctx);
+
+// Start TX processing (call when PTT is pressed)
+bool radae_tx_start(radae_context *ctx);
+
+// Stop TX processing (call when PTT is released)
+void radae_tx_stop(radae_context *ctx);
+
+// Start RX processing
+bool radae_rx_start(radae_context *ctx);
+
+// Stop RX processing
+void radae_rx_stop(radae_context *ctx);
+
+// TX: Feed speech samples (expects 16kHz mono float samples)
+// Returns number of samples written
+int radae_tx_write_speech(radae_context *ctx, const float *samples, int n_samples);
+
+// TX: Get modem IQ samples (8kHz complex float samples, interleaved I,Q,I,Q...)
+// Returns number of complex samples read
+int radae_tx_read_modem_iq(radae_context *ctx, float *iq_samples, int max_samples);
+
+// RX: Feed modem IQ samples (8kHz complex float samples, interleaved I,Q,I,Q...)
+// Returns number of complex samples written
+int radae_rx_write_modem_iq(radae_context *ctx, const float *iq_samples, int n_samples);
+
+// RX: Get speech samples (16kHz mono float samples)
+// Returns number of samples read
+int radae_rx_read_speech(radae_context *ctx, float *samples, int max_samples);
+
+// Sample rate conversion utilities
+void resample_96k_to_16k(const double *in, int in_len, float *out, int *out_len);
+void resample_16k_to_96k(const float *in, int in_len, double *out, int *out_len);
+void resample_48k_to_16k(const double *in, int in_len, float *out, int *out_len);
+void resample_96k_to_8k(const double *in, int in_len, float *out, int *out_len);
+void resample_8k_to_96k(const float *in, int in_len, double *out, int *out_len);
+
+#endif // SBITX_RADAE_H_

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -45,6 +45,7 @@
 
 // Paths to RADAE resources (relative to radae directory)
 #define RADAE_MODEL_PATH         "250725/checkpoints/checkpoint_epoch_200.pth"
+#define RADAE_SYNC_MODEL_PATH    "250725a_ml_sync"
 #define RADAE_DIR                "../radae"
 
 // RADAE context structure

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -138,4 +138,43 @@ void resample_48k_to_16k(const double *in, int in_len, float *out, int *out_len)
 void resample_96k_to_8k(const double *in, int in_len, float *out, int *out_len);
 void resample_8k_to_96k(const float *in, int in_len, double *out, int *out_len);
 
+// True when RADAE_DEBUG env var was set to 1/true at radae_init time.
+bool radae_is_debug(void);
+
+// Amplitude instrumentation: tracks |peak| and mean |val| over a 1 s window
+// for a stream of int64-able samples (so it works for int32, double, float).
+// Gated by radae_is_debug(); silent in production.
+#include <stdio.h>
+#include <stdint.h>
+#include <time.h>
+#include <math.h>
+#define RADAE_AMPL_LOG(tag, val) do {                                          \
+    if (radae_is_debug()) {                                                    \
+        static double   _ap_sum  = 0.0;                                        \
+        static double   _ap_peak = 0.0;                                        \
+        static uint64_t _ap_n    = 0;                                          \
+        static struct timespec _ap_t0 = {0, 0};                                \
+        struct timespec _ap_now;                                               \
+        clock_gettime(CLOCK_MONOTONIC, &_ap_now);                              \
+        if (_ap_t0.tv_sec == 0 && _ap_t0.tv_nsec == 0) _ap_t0 = _ap_now;       \
+        double _ap_v = fabs((double)(val));                                    \
+        _ap_sum += _ap_v;                                                      \
+        if (_ap_v > _ap_peak) _ap_peak = _ap_v;                                \
+        _ap_n += 1;                                                            \
+        double _ap_dt = (_ap_now.tv_sec  - _ap_t0.tv_sec) +                    \
+                        (_ap_now.tv_nsec - _ap_t0.tv_nsec) / 1e9;              \
+        if (_ap_dt >= 1.0) {                                                   \
+            double _ap_mean = _ap_n ? _ap_sum / (double)_ap_n : 0.0;           \
+            fprintf(stderr,                                                    \
+                "RADAE ampl [%s]: peak=%.3g mean=%.3g n=%llu\n",               \
+                (tag), _ap_peak, _ap_mean,                                     \
+                (unsigned long long)_ap_n);                                    \
+            _ap_sum  = 0.0;                                                    \
+            _ap_peak = 0.0;                                                    \
+            _ap_n    = 0;                                                      \
+            _ap_t0   = _ap_now;                                                \
+        }                                                                      \
+    }                                                                          \
+} while (0)
+
 #endif // SBITX_RADAE_H_

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -46,7 +46,7 @@
 // Paths to RADAE resources (relative to radae directory)
 #define RADAE_MODEL_PATH         "250725/checkpoints/checkpoint_epoch_200.pth"
 #define RADAE_SYNC_MODEL_PATH    "250725a_ml_sync"
-#define RADAE_DIR                "../radae"
+#define RADAE_DIR                "/opt/radae"
 
 // RADAE context structure
 typedef struct {

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -61,7 +61,7 @@
 typedef struct {
     // Subprocess PIDs
     pid_t tx_encoder_pid;    // TX encoder pipeline (sh -c, parent of lpcnet_demo + python)
-    pid_t tx_python_pid;     // radae_txe2.py child; target for SIGUSR1 (EOO)
+    pid_t tx_encoder_eoo_pid;     // radae_tx_v2 child PID (target for SIGUSR1 EOO)
     pid_t rx_decoder_pid;    // RX decoder pipeline
 
     // Circular buffers for sample rate conversion
@@ -120,12 +120,12 @@ bool radae_tx_start(radae_context *ctx);
 // Stop TX processing (call when PTT is released)
 void radae_tx_stop(radae_context *ctx);
 
-// Ask radae_txe2.py to emit a V2 end-of-over frame (6 pend_cp symbols).
-// Non-blocking: sends SIGUSR1 to the cached Python PID and returns.  The
-// caller is responsible for giving the IQ time to flow through the
-// modem buffer -> DSP -> DAC before the PA drive is dropped.  Returns
-// false if the Python PID isn't known yet (startup race, or subprocess
-// died).
+// Ask the TX encoder (radae_tx_v2) to emit a V2 end-of-over frame
+// (6 pend_cp symbols).  Non-blocking: sends SIGUSR1 to the cached
+// encoder PID and returns.  The caller is responsible for giving the
+// IQ time to flow through the modem buffer -> DSP -> DAC before the
+// PA drive is dropped.  Returns false if the encoder PID isn't known
+// yet (startup race, or subprocess died).
 bool radae_tx_emit_eoo(radae_context *ctx);
 
 // Start RX processing

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -115,6 +115,9 @@ bool radae_rx_start(radae_context *ctx);
 // Stop RX processing
 void radae_rx_stop(radae_context *ctx);
 
+// Flush RX buffers (call on TX->RX transition to discard stale data)
+void radae_rx_flush(radae_context *ctx);
+
 // TX: Feed speech samples (expects 16kHz mono float samples)
 // Returns number of samples written
 int radae_tx_write_speech(radae_context *ctx, const float *samples, int n_samples);

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -48,10 +48,17 @@
 #define RADAE_SYNC_MODEL_PATH    "250725a_ml_sync"
 #define RADAE_DIR                "/opt/radae"
 
+// radae_txe2.py writes its own PID here at startup; the TX thread reads it
+// back so radae_tx_emit_eoo can deliver SIGUSR1 to Python directly (the
+// fork+exec target is /bin/sh, so tx_encoder_pid points at the shell, not
+// Python).
+#define RADAE_TX_PID_FILE        "/tmp/radae_tx.pid"
+
 // RADAE context structure
 typedef struct {
     // Subprocess PIDs
-    pid_t tx_encoder_pid;    // TX encoder pipeline
+    pid_t tx_encoder_pid;    // TX encoder pipeline (sh -c, parent of lpcnet_demo + python)
+    pid_t tx_python_pid;     // radae_txe2.py child; target for SIGUSR1 (EOO)
     pid_t rx_decoder_pid;    // RX decoder pipeline
 
     // Circular buffers for sample rate conversion
@@ -86,6 +93,7 @@ typedef struct {
     // State flags
     _Atomic bool initialized;
     _Atomic bool tx_running;
+    _Atomic bool tx_eoo_only;    // stop feeding stdin, drain EOO/stdout only
     _Atomic bool rx_running;
     _Atomic bool shutdown_requested;
 
@@ -108,6 +116,14 @@ bool radae_tx_start(radae_context *ctx);
 
 // Stop TX processing (call when PTT is released)
 void radae_tx_stop(radae_context *ctx);
+
+// Ask radae_txe2.py to emit a V2 end-of-over frame (6 pend_cp symbols).
+// Non-blocking: sends SIGUSR1 to the cached Python PID and returns.  The
+// caller is responsible for giving the IQ time to flow through the
+// modem buffer -> DSP -> DAC before the PA drive is dropped.  Returns
+// false if the Python PID isn't known yet (startup race, or subprocess
+// died).
+bool radae_tx_emit_eoo(radae_context *ctx);
 
 // Start RX processing
 bool radae_rx_start(radae_context *ctx);

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -55,6 +55,7 @@
 #define RADAE_DIR_V2             "/opt/radae"
 
 // RADEv1 resources (relative to /opt/radae_nopy)
+#define RADAE_MODEL_PATH_V1      "builtin"
 #define RADAE_RX_BINARY_PATH_V1  "build/src/radae_rx"
 #define RADAE_TX_BINARY_PATH_V1  "build/src/radae_tx"
 #define RADAE_DIR_V1             "/opt/radae_nopy"

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -47,12 +47,14 @@
 #define RADAE_MODEL_PATH         "250725/checkpoints/checkpoint_epoch_200.pth"
 #define RADAE_SYNC_MODEL_PATH    "250725a_ml_sync"
 #define RADAE_RX_BINARY_PATH     "build/src/radae_rx_v2"
+#define RADAE_TX_BINARY_PATH     "build/src/radae_tx_v2"
 #define RADAE_DIR                "/opt/radae"
 
-// radae_txe2.py writes its own PID here at startup; the TX thread reads it
-// back so radae_tx_emit_eoo can deliver SIGUSR1 to Python directly (the
-// fork+exec target is /bin/sh, so tx_encoder_pid points at the shell, not
-// Python).
+// The native TX binary writes its own PID here at startup; the TX thread
+// reads it back so radae_tx_emit_eoo can deliver SIGUSR1 directly (the
+// fork+exec target is /bin/sh, so tx_encoder_pid points at the shell,
+// not the encoder process).  Same contract radae_txe2.py honoured before
+// the C swap.
 #define RADAE_TX_PID_FILE        "/tmp/radae_tx.pid"
 
 // RADAE context structure

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -19,8 +19,7 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  *
- * RADEv2 - Radio Autoencoder Version 2
- * See: https://github.com/drowe67/radae
+ * RADE digital voice integration for RADEv1 and RADEv2.
  */
 
 #ifndef SBITX_RADAE_H_
@@ -43,25 +42,34 @@
 // Feature extraction frame size (10ms @ 16kHz = 160 samples)
 #define RADAE_FRAME_SIZE     160
 
-// Paths to RADAE resources (relative to radae directory)
-#define RADAE_MODEL_PATH         "250725/checkpoints/checkpoint_epoch_200.pth"
-#define RADAE_SYNC_MODEL_PATH    "250725a_ml_sync"
-#define RADAE_RX_BINARY_PATH     "build/src/radae_rx_v2"
-#define RADAE_TX_BINARY_PATH     "build/src/radae_tx_v2"
-#define RADAE_DIR                "/opt/radae"
+// RADE version selection
+#define RADAE_VERSION_V1         "v1"
+#define RADAE_VERSION_V2         "v2"
+#define RADAE_VERSION_DEFAULT    RADAE_VERSION_V2
+
+// RADEv2 resources (relative to /opt/radae)
+#define RADAE_MODEL_PATH_V2      "250725/checkpoints/checkpoint_epoch_200.pth"
+#define RADAE_SYNC_MODEL_PATH_V2 "250725a_ml_sync"
+#define RADAE_RX_BINARY_PATH_V2  "build/src/radae_rx_v2"
+#define RADAE_TX_BINARY_PATH_V2  "build/src/radae_tx_v2"
+#define RADAE_DIR_V2             "/opt/radae"
+
+// RADEv1 resources (relative to /opt/radae_nopy)
+#define RADAE_RX_BINARY_PATH_V1  "build/src/radae_rx"
+#define RADAE_TX_BINARY_PATH_V1  "build/src/radae_tx"
+#define RADAE_DIR_V1             "/opt/radae_nopy"
 
 // The native TX binary writes its own PID here at startup; the TX thread
 // reads it back so radae_tx_emit_eoo can deliver SIGUSR1 directly (the
 // fork+exec target is /bin/sh, so tx_encoder_pid points at the shell,
-// not the encoder process).  Same contract radae_txe2.py honoured before
-// the C swap.
+// not the encoder process).  This contract exists only on RADEv2.
 #define RADAE_TX_PID_FILE        "/tmp/radae_tx.pid"
 
 // RADAE context structure
 typedef struct {
     // Subprocess PIDs
-    pid_t tx_encoder_pid;    // TX encoder pipeline (sh -c, parent of lpcnet_demo + python)
-    pid_t tx_encoder_eoo_pid;     // radae_tx_v2 child PID (target for SIGUSR1 EOO)
+    pid_t tx_encoder_pid;         // TX encoder pipeline shell
+    pid_t tx_encoder_eoo_pid;     // RADEv2 child PID (target for SIGUSR1 EOO)
     pid_t rx_decoder_pid;    // RX decoder pipeline
 
     // Circular buffers for sample rate conversion
@@ -96,7 +104,7 @@ typedef struct {
     // State flags
     _Atomic bool initialized;
     _Atomic bool tx_running;
-    _Atomic bool tx_eoo_only;    // stop feeding stdin, drain EOO/stdout only
+    _Atomic bool tx_eoo_only;    // stop feeding stdin and drain TX output only
     _Atomic bool rx_running;
     _Atomic bool shutdown_requested;
 
@@ -105,11 +113,12 @@ typedef struct {
 
     // RADAE directory path
     char radae_dir[256];
+    char rade_version[8];
 
 } radae_context;
 
 // Initialize RADAE subsystem
-bool radae_init(radae_context *ctx, radio *radio_h, const char *radae_dir);
+bool radae_init(radae_context *ctx, radio *radio_h);
 
 // Shutdown RADAE subsystem
 void radae_shutdown(radae_context *ctx);

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -56,21 +56,22 @@
 
 // RADEv1 resources (relative to /opt/radae_nopy)
 #define RADAE_MODEL_PATH_V1      "builtin"
+#define RADAE_SYNC_MODEL_PATH_V1 "builtin"
 #define RADAE_RX_BINARY_PATH_V1  "build/src/radae_rx"
 #define RADAE_TX_BINARY_PATH_V1  "build/src/radae_tx"
 #define RADAE_DIR_V1             "/opt/radae_nopy"
 
-// The native TX binary writes its own PID here at startup; the TX thread
-// reads it back so radae_tx_emit_eoo can deliver SIGUSR1 directly (the
-// fork+exec target is /bin/sh, so tx_encoder_pid points at the shell,
-// not the encoder process).  This contract exists only on RADEv2.
+// The TX binary writes its own PID here at startup; the TX thread reads it
+// back so radae_tx_emit_eoo can deliver SIGUSR1 directly (the fork+exec
+// target is /bin/sh, so tx_encoder_pid points at the shell, not the encoder
+// process).
 #define RADAE_TX_PID_FILE        "/tmp/radae_tx.pid"
 
 // RADAE context structure
 typedef struct {
     // Subprocess PIDs
     pid_t tx_encoder_pid;         // TX encoder pipeline shell
-    pid_t tx_encoder_eoo_pid;     // RADEv2 child PID (target for SIGUSR1 EOO)
+    pid_t tx_encoder_eoo_pid;     // RADE child PID (target for SIGUSR1 EOO)
     pid_t rx_decoder_pid;    // RX decoder pipeline
 
     // Circular buffers for sample rate conversion
@@ -130,8 +131,8 @@ bool radae_tx_start(radae_context *ctx);
 // Stop TX processing (call when PTT is released)
 void radae_tx_stop(radae_context *ctx);
 
-// Ask the TX encoder (radae_tx_v2) to emit a V2 end-of-over frame
-// (6 pend_cp symbols).  Non-blocking: sends SIGUSR1 to the cached
+// Ask the TX encoder to emit an end-of-over frame. Non-blocking: sends SIGUSR1
+// to the cached
 // encoder PID and returns.  The caller is responsible for giving the
 // IQ time to flow through the modem buffer -> DSP -> DAC before the
 // PA drive is dropped.  Returns false if the encoder PID isn't known

--- a/trx_v2-userland/sbitx_radae.h
+++ b/trx_v2-userland/sbitx_radae.h
@@ -46,6 +46,7 @@
 // Paths to RADAE resources (relative to radae directory)
 #define RADAE_MODEL_PATH         "250725/checkpoints/checkpoint_epoch_200.pth"
 #define RADAE_SYNC_MODEL_PATH    "250725a_ml_sync"
+#define RADAE_RX_BINARY_PATH     "build/src/radae_rx_v2"
 #define RADAE_DIR                "/opt/radae"
 
 // radae_txe2.py writes its own PID here at startup; the TX thread reads it

--- a/trx_v2-userland/sbitx_shm.c
+++ b/trx_v2-userland/sbitx_shm.c
@@ -421,7 +421,6 @@ void *process_radio_command_thread(void *arg)
 
     while(!shutdown_)
     {
-
         pthread_cond_wait(&conn->cmd_condition, &conn->cmd_mutex);
 
         if(shutdown_)


### PR DESCRIPTION
Integrate RADEv2 (Radio Autoencoder Version 2) for ML-based digital voice transmission over HF within the SSB passband.

New files:
- sbitx_radae.h: Header with RADAE context, API, and sample rate conversion
- sbitx_radae.c: Implementation using subprocess pipelines for encoding/decoding

Modified files:
- sbitx_dsp.c: Add digital voice TX/RX processing when digital_voice enabled
- Makefile: Add sbitx_radae.o to build
- README.md: Add RADEv2 build and usage instructions

The implementation uses subprocess pipelines with pipes:
- TX: lpcnet_demo -features | inference.py -> modem IQ at 8kHz
- RX: radae_rxe.py | lpcnet_demo -fargan-synthesis -> speech at 16kHz

RADEv2 parameters: latent_dim=56, w1_dec=128, model=250725

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it modifies the core real-time RX/TX DSP path and introduces long-running threads and external subprocess pipelines (Python/LPCNet) with new buffering and resampling, which can impact audio stability, latency, and shutdown behavior.
> 
> **Overview**
> Adds an optional **RADEv2 digital voice mode** that replaces the normal SSB audio path with RADAE encode/decode when `profile.digital_voice` is enabled.
> 
> Introduces new `sbitx_radae.{c,h}` implementing a RADAE context with circular buffers, TX/RX worker threads, subprocess pipelines (Python + `lpcnet_demo`), and basic sample-rate conversion utilities.
> 
> Updates `sbitx_dsp.c` to initialize/shutdown RADAE, start/stop TX on demand, and route RX/TX audio through RADAE with 96k↔16k/8k resampling; updates the `Makefile` to build/link `sbitx_radae.o`, and expands `README.md` with setup/build/usage instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a26cf29bbffec05edf735713be4d5383fb6a836a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->